### PR TITLE
Change DaisyUI input caret into custom one

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -3,6 +3,7 @@
 @import './styles/tokens.css';
 @import './styles/reset.css';
 @import './styles/number-input.css';
+@import './styles/select.css';
 @import './styles/supervision-tree.css';
 @import './styles/tooltip.css';
 @import './styles/sidebar.css';

--- a/assets/css/styles/select.css
+++ b/assets/css/styles/select.css
@@ -3,10 +3,11 @@
    the control itself lands on subpixel coordinates) those halves misalign —
    the caret looks split, deformed, or half-missing.
 
-   Kill DaisyUI's dual-gradient caret globally, and render a single SVG caret
-   via `.select-caret` wrapper so there is no seam to break under fractional
-   device pixels. Color follows currentColor. */
-.select:not([multiple]) {
+   Wrap any DaisyUI `.select` in `.select-caret` to replace that dual-gradient
+   with a single SVG mask caret (no seam under fractional device pixels).
+   A wrapper is required: <select> does not reliably support ::after in
+   WebKit (Tauri on macOS/Linux). Unwrapped selects keep DaisyUI's caret. */
+.select-caret .select:not([multiple]) {
   background-image: none;
 }
 
@@ -15,6 +16,8 @@
   position: relative;
   display: inline-flex;
   align-items: center;
+  /* Match DaisyUI select text so the mask caret tracks light/dark themes. */
+  color: var(--color-base-content);
 }
 
 .select-caret::after {
@@ -22,8 +25,8 @@
   position: absolute;
   right: 0.75rem;
   top: 50%;
-  width: 0.85rem;
-  height: 0.85rem;
+  width: 1rem;
+  height: 1rem;
   translate: 0 -50%;
   pointer-events: none;
   background-color: currentColor;

--- a/assets/css/styles/select.css
+++ b/assets/css/styles/select.css
@@ -1,0 +1,33 @@
+/* DaisyUI paints the <select> caret as two 4×4px CSS linear-gradient
+   triangles joined at a fractional 16.1px offset. At non-100% zoom (and when
+   the control itself lands on subpixel coordinates) those halves misalign —
+   the caret looks split, deformed, or half-missing.
+
+   Kill DaisyUI's dual-gradient caret globally, and render a single SVG caret
+   via `.select-caret` wrapper so there is no seam to break under fractional
+   device pixels. Color follows currentColor. */
+.select:not([multiple]) {
+  background-image: none;
+}
+
+.select-caret {
+  --select-caret: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath fill='none' stroke='%23000' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round' d='M4 6l4 4 4-4'/%3E%3C/svg%3E");
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+}
+
+.select-caret::after {
+  content: "";
+  position: absolute;
+  right: 0.75rem;
+  top: 50%;
+  width: 0.85rem;
+  height: 0.85rem;
+  translate: 0 -50%;
+  pointer-events: none;
+  background-color: currentColor;
+  opacity: 0.85;
+  -webkit-mask: var(--select-caret) center / contain no-repeat;
+  mask: var(--select-caret) center / contain no-repeat;
+}

--- a/assets/css/styles/select.css
+++ b/assets/css/styles/select.css
@@ -18,7 +18,7 @@
 }
 
 .select-caret::after {
-  content: "";
+  content: '';
   position: absolute;
   right: 0.75rem;
   top: 50%;

--- a/lib/voyager_web/components/core_components.ex
+++ b/lib/voyager_web/components/core_components.ex
@@ -129,19 +129,21 @@ defmodule VoyagerWeb.CoreComponents do
         Auto-refresh
       </label>
       <form phx-change="set_interval" id={"#{@id}-form"}>
-        <select
-          name="interval"
-          id={@id}
-          class="select select-bordered select-sm font-mono pr-8 text-xs"
-        >
-          <option
-            :for={{label, value} <- @options}
-            value={value}
-            selected={value == interval_value(@refresh_interval)}
+        <div class="select-caret">
+          <select
+            name="interval"
+            id={@id}
+            class="select select-bordered select-sm font-mono pr-8 text-xs"
           >
-            {label}
-          </option>
-        </select>
+            <option
+              :for={{label, value} <- @options}
+              value={value}
+              selected={value == interval_value(@refresh_interval)}
+            >
+              {label}
+            </option>
+          </select>
+        </div>
       </form>
       <button
         type="button"
@@ -149,11 +151,11 @@ defmodule VoyagerWeb.CoreComponents do
         phx-throttle="1000"
         id={"#{@id}-refresh-now-button"}
         title="Refresh now"
-        class="btn btn-md btn-ghost btn-square"
+        class="btn btn-sm btn-ghost btn-square"
       >
         <.icon
           name="icon-rotate-cw"
-          class={["size-6", @loading && "animate-spin"]}
+          class={["size-4", @loading && "animate-spin"]}
         />
       </button>
     </div>

--- a/lib/voyager_web/components/core_components.ex
+++ b/lib/voyager_web/components/core_components.ex
@@ -151,11 +151,11 @@ defmodule VoyagerWeb.CoreComponents do
         phx-throttle="1000"
         id={"#{@id}-refresh-now-button"}
         title="Refresh now"
-        class="btn btn-sm btn-ghost btn-square"
+        class="btn btn-md btn-ghost btn-square"
       >
         <.icon
           name="icon-rotate-cw"
-          class={["size-4", @loading && "animate-spin"]}
+          class={["size-6", @loading && "animate-spin"]}
         />
       </button>
     </div>


### PR DESCRIPTION
DaisyUI paints the <select> caret as two 4×4px CSS linear-gradient
   triangles joined at a fractional 16.1px offset. At non-100% zoom (and when
   the control itself lands on subpixel coordinates) those halves misalign —
   the caret looks split, deformed, or half-missing.

   Kill DaisyUI's dual-gradient caret globally, and render a single SVG caret
   via `.select-caret` wrapper so there is no seam to break under fractional
   device pixels. Color follows currentColor.