### PR TITLE
Change default window size on desktop

### DIFF
--- a/rel/app/src-tauri/src/lib.rs
+++ b/rel/app/src-tauri/src/lib.rs
@@ -76,7 +76,7 @@ fn create_window(app_handle: &tauri::AppHandle, port: u16) {
     let url = tauri::WebviewUrl::External(format!("http://127.0.0.1:{port}").parse().unwrap());
     tauri::WebviewWindowBuilder::new(app_handle, format!("window-{}", n), url)
         .title("Voyager")
-        .inner_size(800.0, 800.0)
+        .inner_size(1280.0, 800.0)
         .min_inner_size(800.0, 800.0)
         .build()
         .unwrap();

--- a/rel/app/src-tauri/src/lib.rs
+++ b/rel/app/src-tauri/src/lib.rs
@@ -76,7 +76,7 @@ fn create_window(app_handle: &tauri::AppHandle, port: u16) {
     let url = tauri::WebviewUrl::External(format!("http://127.0.0.1:{port}").parse().unwrap());
     tauri::WebviewWindowBuilder::new(app_handle, format!("window-{}", n), url)
         .title("Voyager")
-        .inner_size(1280.0, 800.0)
+        .inner_size(1280.0, 960.0)
         .min_inner_size(800.0, 800.0)
         .build()
         .unwrap();


### PR DESCRIPTION
1024px is the breakpoint for the media query that decides if the sidebar will be expanded or collapsed, by making the app 1280x800 it makes it expanded by default