### PR TITLE
Fix dependabot cargo config

### DIFF
--- a/.github/workflows/ci-check.yaml
+++ b/.github/workflows/ci-check.yaml
@@ -43,6 +43,10 @@ jobs:
         working-directory: ./dev
         run: bash ./tauri_check_version.sh
 
+      - name: Check ElixirKit rev
+        working-directory: ./dev
+        run: bash ./elixirkit_check_rev.sh
+
       - uses: actions/setup-node@v6
         with:
           node-version-file: .tool-versions

--- a/dev/elixirkit_check_rev.sh
+++ b/dev/elixirkit_check_rev.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+mix_lock="$root_dir/mix.lock"
+cargo_toml="$root_dir/rel/app/src-tauri/Cargo.toml"
+cargo_lock="$root_dir/rel/app/src-tauri/Cargo.lock"
+
+mix_rev="$(
+  sed -n 's/.*"elixirkit": {:git, "[^"]*", "\([^"]*\)".*/\1/p' "$mix_lock" | head -n1
+)"
+
+cargo_toml_rev="$(
+  awk '
+    /^[[:space:]]*elixirkit[[:space:]]*=/ {
+      if (match($0, /rev[[:space:]]*=[[:space:]]*"[^"]+"/)) {
+        s = substr($0, RSTART, RLENGTH)
+        sub(/^rev[[:space:]]*=[[:space:]]*"/, "", s)
+        sub(/"$/, "", s)
+        print s
+        exit
+      }
+    }
+  ' "$cargo_toml"
+)"
+
+cargo_lock_rev="$(
+  awk '
+    /^name = "elixirkit"$/ { in_pkg = 1; next }
+    in_pkg && /^\[\[package\]\]/ { in_pkg = 0 }
+    in_pkg && /^source = / {
+      if (match($0, /rev=[0-9a-f]+/)) {
+        print substr($0, RSTART + 4, RLENGTH - 4)
+        exit
+      }
+      if (match($0, /#[0-9a-f]+"/)) {
+        print substr($0, RSTART + 1, RLENGTH - 2)
+        exit
+      }
+    }
+  ' "$cargo_lock"
+)"
+
+if [ -z "$mix_rev" ] || [ -z "$cargo_toml_rev" ] || [ -z "$cargo_lock_rev" ]; then
+  echo "Unable to read all ElixirKit git revisions." >&2
+  echo "mix.lock: ${mix_rev:-<missing>}" >&2
+  echo "Cargo.toml: ${cargo_toml_rev:-<missing>}" >&2
+  echo "Cargo.lock: ${cargo_lock_rev:-<missing>}" >&2
+  exit 1
+fi
+
+status=0
+
+if [ "$cargo_toml_rev" != "$mix_rev" ]; then
+  echo "rel/app/src-tauri/Cargo.toml: found \"$cargo_toml_rev\", expected \"$mix_rev\" from mix.lock" >&2
+  status=1
+fi
+
+if [ "$cargo_lock_rev" != "$mix_rev" ]; then
+  echo "rel/app/src-tauri/Cargo.lock: found \"$cargo_lock_rev\", expected \"$mix_rev\" from mix.lock" >&2
+  status=1
+fi
+
+if [ "$status" -eq 0 ]; then
+  echo "ElixirKit rev check passed - all files are at $mix_rev"
+fi
+
+exit "$status"

--- a/mix.exs
+++ b/mix.exs
@@ -104,6 +104,7 @@ defmodule Voyager.MixProject do
       ],
       precommit: [
         tauri_check_version_cmd(),
+        elixirkit_check_rev_cmd(),
         "deps.unlock --unused",
         "compile --warnings-as-errors",
         "format",
@@ -135,4 +136,6 @@ defmodule Voyager.MixProject do
   end
 
   defp tauri_check_version_cmd, do: "cmd dev/tauri_check_version.sh"
+
+  defp elixirkit_check_rev_cmd, do: "cmd dev/elixirkit_check_rev.sh"
 end

--- a/rel/app/src-tauri/Cargo.lock
+++ b/rel/app/src-tauri/Cargo.lock
@@ -968,6 +968,7 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 [[package]]
 name = "elixirkit"
 version = "0.1.0"
+source = "git+https://github.com/livebook-dev/elixirkit.git?rev=16d19dd3fe7ad0c0e38a1667a90ed7962ed477c7#16d19dd3fe7ad0c0e38a1667a90ed7962ed477c7"
 
 [[package]]
 name = "embed-resource"

--- a/rel/app/src-tauri/Cargo.toml
+++ b/rel/app/src-tauri/Cargo.toml
@@ -21,7 +21,7 @@ tauri-build = { version = "2", features = [] }
 [dependencies]
 tauri = { version = "2", features = [] }
 tauri-plugin-opener = "2"
-elixirkit = { path = "../../../deps/elixirkit/elixirkit_rs" }
+elixirkit = { git = "https://github.com/livebook-dev/elixirkit.git", rev = "16d19dd3fe7ad0c0e38a1667a90ed7962ed477c7" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 fix-path-env = { git = "https://github.com/tauri-apps/fix-path-env-rs", rev = "c4c45d5" }


### PR DESCRIPTION
Switch Tauri elixirkit from a Mix deps/ path to a git dep (same SHA as mix.lock) so Dependabot cargo works. Add dev/elixirkit_check_rev.sh (CI + precommit) to keep Mix and Cargo revs in sync.