### PR TITLE
Add feedback link button to sidebar

### DIFF
--- a/assets/css/icons/message-square-share.svg
+++ b/assets/css/icons/message-square-share.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-message-square-share-icon lucide-message-square-share"><path d="M21 12v3a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h7"/><path d="M16 3h5v5"/><path d="m16 8 5-5"/></svg>

--- a/assets/css/styles/sidebar.css
+++ b/assets/css/styles/sidebar.css
@@ -54,7 +54,8 @@
   justify-content: center;
 }
 
-#app-sidebar.mode-full #mcp-status {
+#app-sidebar.mode-full #mcp-status,
+#app-sidebar.mode-full #sidebar-feedback {
   margin-left: 0.5rem;
 }
 

--- a/lib/voyager_web/components/shell.ex
+++ b/lib/voyager_web/components/shell.ex
@@ -116,7 +116,7 @@ defmodule VoyagerWeb.Components.Shell do
         class="sidebar-nav-row text-base-content/70 flex w-full items-center justify-start gap-2 rounded-md px-2 py-1.5 hover:text-base-content"
       >
         <.icon name="icon-message-square-share" class="toolbar-icon text-base-content/70 shrink-0" />
-        <span class="sidebar-label text-base-content/70 truncate">Feedback</span>
+        <span class="sidebar-label font-mono text-base-content/70 truncate text-xs">Feedback</span>
       </a>
       <:content>Share your feedback with us here!</:content>
     </.tooltip>

--- a/lib/voyager_web/components/shell.ex
+++ b/lib/voyager_web/components/shell.ex
@@ -113,6 +113,7 @@ defmodule VoyagerWeb.Components.Shell do
         href={@feedback_url}
         target="_blank"
         rel="noopener noreferrer"
+        aria-label="Feedback"
         class="sidebar-nav-row text-base-content/70 flex w-full items-center justify-start gap-2 rounded-md px-2 py-1.5 hover:text-base-content"
       >
         <.icon name="icon-message-square-share" class="toolbar-icon text-base-content/70 shrink-0" />

--- a/lib/voyager_web/components/shell.ex
+++ b/lib/voyager_web/components/shell.ex
@@ -241,7 +241,7 @@ defmodule VoyagerWeb.Components.Shell do
         </.nav_item>
       </ul>
 
-      <div class="mb-1.5 flex flex-none flex-col p-3 pb-0">
+      <div class="mb-2.5 flex flex-none flex-col p-3 pb-0">
         <.feedback_link />
       </div>
 

--- a/lib/voyager_web/components/shell.ex
+++ b/lib/voyager_web/components/shell.ex
@@ -101,6 +101,28 @@ defmodule VoyagerWeb.Components.Shell do
     """
   end
 
+  @feedback_url "https://github.com/software-mansion-labs/voyager-early-access-feedback/issues/new/choose"
+
+  defp feedback_link(assigns) do
+    assigns = assign(assigns, :feedback_url, @feedback_url)
+
+    ~H"""
+    <.tooltip id="sidebar-feedback-tip" position="top" class="w-full">
+      <a
+        id="sidebar-feedback"
+        href={@feedback_url}
+        target="_blank"
+        rel="noopener noreferrer"
+        class="sidebar-nav-row text-base-content/70 flex w-full items-center justify-start gap-2 rounded-md px-2 py-1.5 hover:text-base-content"
+      >
+        <.icon name="icon-message-square-share" class="toolbar-icon text-base-content/70 shrink-0" />
+        <span class="sidebar-label text-base-content/70 truncate">Feedback</span>
+      </a>
+      <:content>Share your feedback with us here!</:content>
+    </.tooltip>
+    """
+  end
+
   attr :status, :map, required: true
   attr :active_nav, :atom, default: nil
   attr :session, Session, required: true
@@ -217,6 +239,10 @@ defmodule VoyagerWeb.Components.Shell do
           <:icon><.icon name={page.icon} class="toolbar-icon" /></:icon>
         </.nav_item>
       </ul>
+
+      <div class="flex flex-none flex-col p-3 pb-0 mb-1.5">
+        <.feedback_link />
+      </div>
 
       <div class="border-base-content/10 mx-4 border-t"></div>
 

--- a/lib/voyager_web/components/shell.ex
+++ b/lib/voyager_web/components/shell.ex
@@ -116,8 +116,8 @@ defmodule VoyagerWeb.Components.Shell do
         aria-label="Feedback"
         class="sidebar-nav-row text-base-content/70 flex w-full items-center justify-start gap-2 rounded-md px-2 py-1.5 hover:text-base-content"
       >
-        <.icon name="icon-message-square-share" class="toolbar-icon text-base-content/70 shrink-0" />
-        <span class="sidebar-label font-mono text-base-content/70 truncate text-xs">Feedback</span>
+        <.icon name="icon-message-square-share" class="toolbar-icon shrink-0" />
+        <span class="sidebar-label font-mono truncate text-xs">Feedback</span>
       </a>
       <:content>Share your feedback with us here!</:content>
     </.tooltip>

--- a/lib/voyager_web/components/shell.ex
+++ b/lib/voyager_web/components/shell.ex
@@ -245,7 +245,7 @@ defmodule VoyagerWeb.Components.Shell do
         <.feedback_link />
       </div>
 
-      <div class="border-base-content/10 mx-[length:var(--sidebar-compact-pad)] border-t"></div>
+      <div class="border-base-content/10 border-t mx-[length:var(--sidebar-compact-pad)]"></div>
 
       <div class="flex flex-none flex-col gap-1 p-3">
         <.mcp_status_indicator

--- a/lib/voyager_web/components/shell.ex
+++ b/lib/voyager_web/components/shell.ex
@@ -240,7 +240,7 @@ defmodule VoyagerWeb.Components.Shell do
         </.nav_item>
       </ul>
 
-      <div class="flex flex-none flex-col p-3 pb-0 mb-1.5">
+      <div class="mb-1.5 flex flex-none flex-col p-3 pb-0">
         <.feedback_link />
       </div>
 

--- a/lib/voyager_web/components/shell.ex
+++ b/lib/voyager_web/components/shell.ex
@@ -245,7 +245,7 @@ defmodule VoyagerWeb.Components.Shell do
         <.feedback_link />
       </div>
 
-      <div class="border-base-content/10 mx-4 border-t"></div>
+      <div class="border-base-content/10 mx-[length:var(--sidebar-compact-pad)] border-t"></div>
 
       <div class="flex flex-none flex-col gap-1 p-3">
         <.mcp_status_indicator

--- a/test/voyager_web/live/node_info_live_test.exs
+++ b/test/voyager_web/live/node_info_live_test.exs
@@ -28,6 +28,17 @@ defmodule VoyagerWeb.NodeInfoLiveTest do
 
       assert has_element?(view, "#mcp-status")
     end
+
+    test "shows the feedback link", %{conn: conn} do
+      stub_erpc(Fakes.node_data())
+
+      {:ok, view, _html} = live(conn, @path)
+
+      assert has_element?(
+               view,
+               "#sidebar-feedback[href='https://github.com/software-mansion-labs/voyager-early-access-feedback/issues/new/choose']"
+             )
+    end
   end
 
   describe "mount with a reachable node" do


### PR DESCRIPTION
Summary
Adds a Feedback link in the sidebar (above the MCP divider) that opens the early-access GitHub issue chooser
Icon-only when collapsed; “Feedback” label when expanded, styled like MCP