### PR TITLE
Add single window plugin and linux template

### DIFF
--- a/rel/app/src-tauri/Cargo.lock
+++ b/rel/app/src-tauri/Cargo.lock
@@ -15,6 +15,7 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-opener",
+ "tauri-plugin-single-instance",
 ]
 
 [[package]]
@@ -3763,6 +3764,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-single-instance"
+version = "2.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3214becf9ef5783c0ae99a3bb25adf5353a7a16ebf53e74b909e29205735c6c"
+dependencies = [
+ "serde",
+ "serde_json",
+ "tauri",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "windows-sys 0.60.2",
+ "zbus",
+]
+
+[[package]]
 name = "tauri-runtime"
 version = "2.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4871,6 +4888,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -4917,11 +4943,28 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link 0.2.1",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -4961,6 +5004,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4977,6 +5026,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4997,10 +5052,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -5021,6 +5088,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5037,6 +5110,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -5057,6 +5136,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5073,6 +5158,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"

--- a/rel/app/src-tauri/Cargo.toml
+++ b/rel/app/src-tauri/Cargo.toml
@@ -21,6 +21,7 @@ tauri-build = { version = "2", features = [] }
 [dependencies]
 tauri = { version = "2", features = [] }
 tauri-plugin-opener = "2"
+tauri-plugin-single-instance = "2"
 elixirkit = { git = "https://github.com/livebook-dev/elixirkit.git", rev = "16d19dd3fe7ad0c0e38a1667a90ed7962ed477c7" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/rel/app/src-tauri/linux/voyager.desktop
+++ b/rel/app/src-tauri/linux/voyager.desktop
@@ -1,0 +1,15 @@
+[Desktop Entry]
+Categories={{categories}}
+{{#if comment}}
+Comment={{comment}}
+{{/if}}
+Exec={{exec}}
+StartupWMClass={{exec}}
+Icon={{icon}}
+Name={{name}}
+Terminal=false
+Type=Application
+SingleMainWindow=true
+{{#if mime_type}}
+MimeType={{mime_type}}
+{{/if}}

--- a/rel/app/src-tauri/linux/voyager.desktop
+++ b/rel/app/src-tauri/linux/voyager.desktop
@@ -1,3 +1,9 @@
+# Wired via bundle.linux.deb.desktopTemplate (AppImage reuses that) and rpm.
+# SingleMainWindow hides GNOME "New Window" only when this .desktop is registered
+# (installed package or AppImageLauncher). A raw AppImage / mix tauri.dev may still
+# show the menu item; tauri-plugin-single-instance still prevents a second Elixir.
+# StartupWMClass={{exec}} is the binary name (Voyager). On Linux verify it matches
+# the window: xprop WM_CLASS (X11) or the Wayland app id. If not, set the observed class.
 [Desktop Entry]
 Categories={{categories}}
 {{#if comment}}

--- a/rel/app/src-tauri/src/lib.rs
+++ b/rel/app/src-tauri/src/lib.rs
@@ -89,6 +89,8 @@ fn focus_existing_window(app: &tauri::AppHandle) {
         let _ = window.unminimize();
         let _ = window.show();
         let _ = window.set_focus();
+        // Wayland often ignores set_focus but still reports Ok. No-op if already focused.
+        let _ = window.request_user_attention(Some(tauri::UserAttentionType::Informational));
     }
 }
 

--- a/rel/app/src-tauri/src/lib.rs
+++ b/rel/app/src-tauri/src/lib.rs
@@ -85,11 +85,9 @@ pub fn run() {
 }
 
 fn focus_existing_window(app: &tauri::AppHandle) {
-    if let Some(window) = app
-        .get_webview_window(MAIN_WINDOW_LABEL)
-        .or_else(|| app.webview_windows().into_values().next())
-    {
+    if let Some(window) = app.get_webview_window(MAIN_WINDOW_LABEL) {
         let _ = window.unminimize();
+        let _ = window.show();
         let _ = window.set_focus();
     }
 }
@@ -118,13 +116,24 @@ fn create_window(app_handle: &tauri::AppHandle, port: u16) {
 })();"#,
     ]
     .concat();
-    tauri::WebviewWindowBuilder::new(app_handle, MAIN_WINDOW_LABEL, url)
+    let builder = tauri::WebviewWindowBuilder::new(app_handle, MAIN_WINDOW_LABEL, url)
         .title("Voyager")
         .inner_size(1280.0, 960.0)
         .min_inner_size(800.0, 800.0)
-        .initialization_script(theme_init)
-        .build()
-        .unwrap();
+        .initialization_script(theme_init);
+
+    #[cfg_attr(target_os = "macos", allow(unused_variables))]
+    let window = builder.build().unwrap();
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        let app_handle = window.app_handle().clone();
+        window.on_window_event(move |event| {
+            if let tauri::WindowEvent::Destroyed = event {
+                app_handle.exit(0);
+            }
+        });
+    }
 }
 
 fn elixir_command(

--- a/rel/app/src-tauri/src/lib.rs
+++ b/rel/app/src-tauri/src/lib.rs
@@ -5,6 +5,8 @@ use tauri::{
     menu::{MenuBuilder, SubmenuBuilder},
 };
 
+const MAIN_WINDOW_LABEL: &str = "main";
+
 /// Current OS appearance for Auto theme after full page reloads.
 #[tauri::command]
 fn os_theme() -> &'static str {
@@ -13,9 +15,11 @@ fn os_theme() -> &'static str {
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
-    let pubsub = elixirkit::PubSub::listen("tcp://127.0.0.1:0").expect("failed to listen");
-
     tauri::Builder::default()
+        // Must be registered first so a second launch exits before Elixir starts.
+        .plugin(tauri_plugin_single_instance::init(|app, _argv, _cwd| {
+            focus_existing_window(app);
+        }))
         .enable_macos_default_menu(false)
         .plugin(tauri_plugin_opener::init())
         .invoke_handler(tauri::generate_handler![os_theme])
@@ -41,6 +45,8 @@ pub fn run() {
                     .build()?;
                 app.set_menu(menu)?;
             }
+
+            let pubsub = elixirkit::PubSub::listen("tcp://127.0.0.1:0").expect("failed to listen");
 
             let app_handle = app.handle().clone();
             let port =
@@ -78,8 +84,22 @@ pub fn run() {
         .expect("error while running tauri application");
 }
 
+fn focus_existing_window(app: &tauri::AppHandle) {
+    if let Some(window) = app
+        .get_webview_window(MAIN_WINDOW_LABEL)
+        .or_else(|| app.webview_windows().into_values().next())
+    {
+        let _ = window.unminimize();
+        let _ = window.set_focus();
+    }
+}
+
 fn create_window(app_handle: &tauri::AppHandle, port: u16) {
-    let n = app_handle.webview_windows().len() + 1;
+    if app_handle.get_webview_window(MAIN_WINDOW_LABEL).is_some() {
+        focus_existing_window(app_handle);
+        return;
+    }
+
     let url = tauri::WebviewUrl::External(format!("http://127.0.0.1:{port}").parse().unwrap());
     // Prefer sessionStorage over create-time detect on reload.
     let theme = utils::os_theme_hint();
@@ -98,7 +118,7 @@ fn create_window(app_handle: &tauri::AppHandle, port: u16) {
 })();"#,
     ]
     .concat();
-    tauri::WebviewWindowBuilder::new(app_handle, format!("window-{}", n), url)
+    tauri::WebviewWindowBuilder::new(app_handle, MAIN_WINDOW_LABEL, url)
         .title("Voyager")
         .inner_size(1280.0, 960.0)
         .min_inner_size(800.0, 800.0)

--- a/rel/app/src-tauri/tauri.conf.json
+++ b/rel/app/src-tauri/tauri.conf.json
@@ -19,6 +19,14 @@
       "icons/128x128@2x.png",
       "icons/icon.icns",
       "icons/icon.ico"
-    ]
+    ],
+    "linux": {
+      "deb": {
+        "desktopTemplate": "linux/voyager.desktop"
+      },
+      "rpm": {
+        "desktopTemplate": "linux/voyager.desktop"
+      }
+    }
   }
 }


### PR DESCRIPTION
Limit Linux (and other desktops) to one Tauri process/window so a second launch cannot start a second Elixir.

GNOME’s New Window action starts a new process. Voyager already runs Phoenix in-process, so that meant a second BEAM, a second SQLite, and a second listen on localhost. This change treats “one desktop app” as “one Elixir.”

Summary
- Register tauri-plugin-single-instance first. A second launch notifies the running app, then exits before PubSub/Elixir start. PubSub listen moved into setup so the second process never binds TCP.
- Create a single webview labeled main. A duplicate ready focuses that window instead of building window-N.
- On non-macOS, window Destroyed calls app.exit(0) so closing the only window does not leave a headless process that still owns the D-Bus name.
- Custom .desktop (SingleMainWindow=true, StartupWMClass={{exec}}) via bundle.linux.deb.desktopTemplate (AppImage reuses the deb data dir). Hides GNOME New Window only when the desktop file is registered; the plugin is the actual lock.

macOS keeps the red-button-does-not-quit behavior. The process lock is not Linux-only: one SQLite/Elixir is a desktop-wide constraint.