### PR TITLE
Chore: add banners to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@
 
 </div>
 
+[![Ad](https://swm-delivery.com/www/images/zone-gh-voyager-1?n=1)](https://swm-delivery.com/www/delivery/ck-slug.php?zoneid=zone-gh-voyager-1&n=1)
+[![Ad](https://swm-delivery.com/www/images/zone-gh-voyager-2?n=1)](https://swm-delivery.com/www/delivery/ck-slug.php?zoneid=zone-gh-voyager-2&n=1)
+[![Ad](https://swm-delivery.com/www/images/zone-gh-voyager-3?n=1)](https://swm-delivery.com/www/delivery/ck-slug.php?zoneid=zone-gh-voyager-3&n=1)
+
 https://github.com/user-attachments/assets/8aa3f69e-a692-4b9d-9bf5-75d972f6370f
 
 ## Overview


### PR DESCRIPTION
Adds dynamic banners to readme. The image and link are served from our delivery server, so we can swap banners without changing the repo. Banners are hidden for now until we turn them on.