### PR TITLE
Fix: Bind prod endpoint to loopback instead of all interfaces

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -57,6 +57,6 @@ if config_env() == :prod do
 
   config :voyager, VoyagerWeb.Endpoint,
     url: [host: host, port: port, scheme: "http"],
-    http: [ip: {0, 0, 0, 0, 0, 0, 0, 0}],
+    http: [ip: {127, 0, 0, 1}],
     secret_key_base: secret_key_base
 end


### PR DESCRIPTION
## Problem

The packaged prod endpoint binds to all interfaces:

```elixir
# config/runtime.exs (prod)
http: [ip: {0, 0, 0, 0, 0, 0, 0, 0}]
```

Confirmed at runtime (`beam.smp TCP *:4005 (LISTEN)`) and reachable cross-machine (`nmap 4005/tcp open`). Voyager is a local desktop app — Tauri loads `http://127.0.0.1:PORT` — so listening on the LAN only exposes the node-control UI (saved cookies, SSH passwords, BEAM distribution) to other hosts on the network. The Rust launcher already implies loopback (`available_port` probes `127.0.0.1`, `PHX_HOST=127.0.0.1`); only the listen IP was wrong.

## Fix

Bind to loopback:

```elixir
http: [ip: {127, 0, 0, 1}]
```

No UX change — the app still reaches itself on `127.0.0.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)