### PR TITLE
Enhancement: Rate limit process info refresh in details panel

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -3,6 +3,10 @@ import Config
 # Disable node info auto-refresh in tests so LiveViews don't schedule timers.
 config :voyager, :node_info_refresh_interval_ms, nil
 
+# Tests drive refreshes back to back; rate limiting is exercised explicitly in
+# details_panel_test.exs.
+config :voyager, :process_info_min_refresh_ms, 0
+
 config :voyager, Voyager.Vault,
   ciphers: [
     default: {Cloak.Ciphers.AES.GCM, tag: "AES.GCM.V1", key: <<0::256>>}

--- a/lib/voyager_web/live/supervision_tree_live/details_panel.ex
+++ b/lib/voyager_web/live/supervision_tree_live/details_panel.ex
@@ -25,6 +25,8 @@ defmodule VoyagerWeb.SupervisionTreeLive.DetailsPanel do
 
   require Logger
 
+  @default_min_refresh_ms 1_000
+
   @impl true
   def mount(socket) do
     socket
@@ -33,6 +35,7 @@ defmodule VoyagerWeb.SupervisionTreeLive.DetailsPanel do
     |> assign(:open?, false)
     |> assign(:links_expanded?, false)
     |> assign(:node_info, AsyncResult.loading())
+    |> assign(:last_fetched_at, nil)
     |> ok()
   end
 
@@ -106,32 +109,51 @@ defmodule VoyagerWeb.SupervisionTreeLive.DetailsPanel do
   defp maybe_assign_node(socket, nil), do: assign(socket, :open?, false)
 
   defp maybe_assign_node(socket, node) do
+    changed? = node_changed?(socket, node)
+
     socket =
       socket
       |> assign(:open?, true)
       |> assign(:node, node)
-      |> maybe_fetch_node_info(node)
+      |> maybe_fetch_node_info(node, changed?)
 
-    if node_changed?(socket, node) do
+    if changed? do
       assign(socket, :links_expanded?, false)
     else
       socket
     end
   end
 
-  defp maybe_fetch_node_info(socket, %TreeNode{pid: pid}) when is_pid(pid) do
-    remote_node = socket.assigns.remote_node
+  # Manual refreshes and parent tree updates both land here, so the rate limit
+  # lives at the single fetch point. Selecting another node always fetches.
+  defp maybe_fetch_node_info(socket, node, force? \\ false)
 
-    socket
-    |> assign(:node_info, AsyncResult.loading())
-    |> assign_async(:node_info, fn -> fetch_node_info(remote_node, pid) end)
+  defp maybe_fetch_node_info(socket, %TreeNode{pid: pid}, force?) when is_pid(pid) do
+    now = System.monotonic_time(:millisecond)
+
+    if force? or stale?(socket.assigns.last_fetched_at, now) do
+      remote_node = socket.assigns.remote_node
+
+      socket
+      |> assign(:last_fetched_at, now)
+      |> assign(:node_info, AsyncResult.loading())
+      |> assign_async(:node_info, fn -> fetch_node_info(remote_node, pid) end)
+    else
+      socket
+    end
   end
 
   # Nothing to fetch for apps, ports and references: settle the async assign so
   # the body never shows a load state it will not leave.
-  defp maybe_fetch_node_info(socket, _node) do
+  defp maybe_fetch_node_info(socket, _node, _force?) do
     assign(socket, :node_info, AsyncResult.ok(nil))
   end
+
+  defp stale?(nil, _now), do: true
+  defp stale?(last_fetched_at, now), do: now - last_fetched_at >= min_refresh_ms()
+
+  defp min_refresh_ms,
+    do: Application.get_env(:voyager, :process_info_min_refresh_ms, @default_min_refresh_ms)
 
   defp node_changed?(socket, node) do
     case socket.assigns[:node] do

--- a/test/voyager_web/live/supervision_tree_live/details_panel_test.exs
+++ b/test/voyager_web/live/supervision_tree_live/details_panel_test.exs
@@ -221,6 +221,31 @@ defmodule VoyagerWeb.SupervisionTreeLive.DetailsPanelTest do
       refute has_element?(view, "#details-panel", "Failed to load node details.")
     end
 
+    test "refresh button is rate limited", %{
+      conn: conn,
+      sup_pid: sup_pid,
+      port: port,
+      link_pids: link_pids,
+      sup_key: sup_key
+    } do
+      Application.put_env(:voyager, :process_info_min_refresh_ms, 1_000)
+      on_exit(fn -> Application.put_env(:voyager, :process_info_min_refresh_ms, 0) end)
+
+      # Exactly the calls the initial open needs: a second fetch would blow the
+      # expectation and surface as a failed panel.
+      expect_supervision_erpc(9, sup_pid, [port], link_pids)
+
+      view = open_tree!(conn)
+      render_hook(view, "select-node", %{"key" => sup_key})
+      render_async(view)
+
+      view |> element("#details-panel-refresh") |> render_click()
+      render_async(view)
+
+      assert has_element?(view, "#details-panel", "1,234")
+      refute has_element?(view, "#details-panel", "Failed to load node details.")
+    end
+
     test "refresh button is hidden for non-process nodes", %{
       conn: conn,
       sup_pid: sup_pid,

--- a/test/voyager_web/live/supervision_tree_live/details_panel_test.exs
+++ b/test/voyager_web/live/supervision_tree_live/details_panel_test.exs
@@ -151,6 +151,39 @@ defmodule VoyagerWeb.SupervisionTreeLive.DetailsPanelTest do
       refute has_element?(view, "#details-panel", twentieth_link)
     end
 
+    test "collapses expanded links when another node is selected", %{
+      conn: conn,
+      sup_pid: sup_pid,
+      port: port,
+      link_pids: link_pids,
+      sup_key: sup_key,
+      port_key: port_key,
+      twentieth_link: twentieth_link
+    } do
+      # The 9 calls of the initial open plus the process_info/system_info pair
+      # of re-selecting the supervisor.
+      expect_supervision_erpc(11, sup_pid, [port], link_pids)
+
+      view = open_tree!(conn)
+      render_hook(view, "select-node", %{"key" => sup_key})
+      render_async(view)
+
+      view |> element("#details-panel-toggle-links") |> render_click()
+
+      assert has_element?(view, "#details-panel-toggle-links", "Show Less")
+      assert has_element?(view, "#details-panel", twentieth_link)
+
+      # The port carries no process info, so only the selection changes.
+      render_hook(view, "select-node", %{"key" => port_key})
+      render(view)
+
+      render_hook(view, "select-node", %{"key" => sup_key})
+      render_async(view)
+
+      assert has_element?(view, "#details-panel-toggle-links", "Show More")
+      refute has_element?(view, "#details-panel", twentieth_link)
+    end
+
     test "caps the expanded link list", %{
       conn: conn,
       sup_pid: sup_pid,
@@ -228,8 +261,9 @@ defmodule VoyagerWeb.SupervisionTreeLive.DetailsPanelTest do
       link_pids: link_pids,
       sup_key: sup_key
     } do
+      previous = Application.get_env(:voyager, :process_info_min_refresh_ms)
       Application.put_env(:voyager, :process_info_min_refresh_ms, 1_000)
-      on_exit(fn -> Application.put_env(:voyager, :process_info_min_refresh_ms, 0) end)
+      on_exit(fn -> Application.put_env(:voyager, :process_info_min_refresh_ms, previous) end)
 
       # Exactly the calls the initial open needs: a second fetch would blow the
       # expectation and surface as a failed panel.

--- a/test/voyager_web/live/supervision_tree_live/details_panel_test.exs
+++ b/test/voyager_web/live/supervision_tree_live/details_panel_test.exs
@@ -261,8 +261,9 @@ defmodule VoyagerWeb.SupervisionTreeLive.DetailsPanelTest do
       link_pids: link_pids,
       sup_key: sup_key
     } do
+      # Large enough that a slow CI run cannot outwait the window mid-test.
       previous = Application.get_env(:voyager, :process_info_min_refresh_ms)
-      Application.put_env(:voyager, :process_info_min_refresh_ms, 1_000)
+      Application.put_env(:voyager, :process_info_min_refresh_ms, :timer.hours(1))
       on_exit(fn -> Application.put_env(:voyager, :process_info_min_refresh_ms, previous) end)
 
       # Exactly the calls the initial open needs: a second fetch would blow the


### PR DESCRIPTION
Closes VOY-100.

## What

Server-side 1s rate limit on process info fetches in the supervision tree details panel.

- Limit lives in `maybe_fetch_node_info/3`, the single point both manual refresh clicks and parent tree updates go through — guarding only the click handler would leave the other caller unlimited.
- Selecting a different node always fetches (`force?`), so switching processes never shows stale data.
- Window configurable via `:process_info_min_refresh_ms`, set to `0` in the test env so existing tests keep driving refreshes back to back. New test flips it to `1000` and asserts a second click does not hit `:erpc`.

## Why

The refresh button had only `phx-throttle="1000"`, which is client-side. Nothing stopped a fast or misbehaving client from hammering `:erpc` process info calls on the connected node.

## Drive-by fix

`node_changed?/2` was evaluated *after* `assign(:node, node)`, so it always returned `false` and `links_expanded?` never reset when selecting another node.

## Not done

Auto-refresh interval picker for the panel — per the ticket discussion, waiting for user feedback first.

## Testing

`mix precommit` green (349 Elixir tests + Rust). Verified the new test fails when the rate limit is disabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)