### PR TITLE
Improvement: Put auto-refresh interval in query params

### DIFF
--- a/lib/voyager_web/components/core_components.ex
+++ b/lib/voyager_web/components/core_components.ex
@@ -14,6 +14,7 @@ defmodule VoyagerWeb.CoreComponents do
 
   alias Phoenix.LiveView.JS
   alias VoyagerWeb.Formatters
+  alias VoyagerWeb.Utils.RefreshInterval
 
   @doc """
   Renders flash notices.
@@ -157,7 +158,7 @@ defmodule VoyagerWeb.CoreComponents do
             <option
               :for={{label, value} <- @options}
               value={value}
-              selected={value == interval_value(@refresh_interval)}
+              selected={value == RefreshInterval.to_param(@refresh_interval)}
             >
               {label}
             </option>
@@ -180,9 +181,6 @@ defmodule VoyagerWeb.CoreComponents do
     </div>
     """
   end
-
-  defp interval_value(nil), do: "off"
-  defp interval_value(ms), do: Integer.to_string(ms)
 
   @doc """
   Renders a button that copies text from another element.

--- a/lib/voyager_web/components/supervision_tree_components.ex
+++ b/lib/voyager_web/components/supervision_tree_components.ex
@@ -330,8 +330,14 @@ defmodule VoyagerWeb.Components.SupervisionTreeComponents do
     """
   end
 
-  defp interval_options, do: @interval_options
+  @doc """
+  Auto-refresh options offered by the supervision-tree header, as
+  `{label, param value}` pairs.
+  """
+  @spec interval_options() :: [{String.t(), String.t()}]
+  def interval_options, do: @interval_options
 
+  @spec default_refresh_interval() :: pos_integer()
   def default_refresh_interval,
     do:
       interval_options()

--- a/lib/voyager_web/live/node_info_live.ex
+++ b/lib/voyager_web/live/node_info_live.ex
@@ -7,6 +7,8 @@ defmodule VoyagerWeb.NodeInfoLive do
   alias VoyagerWeb.Formatters
   alias VoyagerWeb.NodeInfoComponents
   alias VoyagerWeb.NodeInfoHelp
+  alias VoyagerWeb.Utils.RefreshInterval
+  alias VoyagerWeb.Utils.URL
 
   @default_interval Application.compile_env(:voyager, :node_info_refresh_interval_ms, 5_000)
   @applications_page_size 10
@@ -42,6 +44,22 @@ defmodule VoyagerWeb.NodeInfoLive do
       end
 
     {:ok, socket}
+  end
+
+  # The interval is routed state: `set_interval` only patches the URL, and the
+  # timer is (re)scheduled from here so a reload or a shared link keeps it.
+  @impl true
+  def handle_params(params, _uri, socket) do
+    interval = RefreshInterval.from_params(params, interval_options(), @default_interval)
+
+    if interval == socket.assigns.refresh_interval do
+      socket
+    else
+      socket
+      |> assign(:refresh_interval, interval)
+      |> schedule_refresh()
+    end
+    |> noreply()
   end
 
   @impl true
@@ -201,9 +219,15 @@ defmodule VoyagerWeb.NodeInfoLive do
   end
 
   def handle_event("set_interval", %{"interval" => value}, socket) do
+    param =
+      value
+      |> RefreshInterval.from_value(interval_options(), @default_interval)
+      |> RefreshInterval.to_param()
+
     socket
-    |> assign(:refresh_interval, parse_interval(value))
-    |> schedule_refresh()
+    |> push_patch(
+      to: URL.put_query_param(socket.assigns.current_url, RefreshInterval.param(), param)
+    )
     |> noreply()
   end
 
@@ -311,15 +335,6 @@ defmodule VoyagerWeb.NodeInfoLive do
   end
 
   defp interval_options, do: @interval_options
-
-  defp parse_interval("off"), do: nil
-
-  defp parse_interval(value) do
-    case Integer.parse(value) do
-      {ms, ""} when ms > 0 -> ms
-      _ -> nil
-    end
-  end
 
   defp format_error(:noconnection), do: "Node is unreachable."
   defp format_error(:timeout), do: "Timed out while fetching node info."

--- a/lib/voyager_web/live/node_info_live.ex
+++ b/lib/voyager_web/live/node_info_live.ex
@@ -8,7 +8,6 @@ defmodule VoyagerWeb.NodeInfoLive do
   alias VoyagerWeb.NodeInfoComponents
   alias VoyagerWeb.NodeInfoHelp
   alias VoyagerWeb.Utils.RefreshInterval
-  alias VoyagerWeb.Utils.URL
 
   @default_interval Application.compile_env(:voyager, :node_info_refresh_interval_ms, 5_000)
   @applications_page_size 10
@@ -219,14 +218,15 @@ defmodule VoyagerWeb.NodeInfoLive do
   end
 
   def handle_event("set_interval", %{"interval" => value}, socket) do
-    param =
-      value
-      |> RefreshInterval.from_value(interval_options(), @default_interval)
-      |> RefreshInterval.to_param()
-
     socket
     |> push_patch(
-      to: URL.put_query_param(socket.assigns.current_url, RefreshInterval.param(), param)
+      to:
+        RefreshInterval.put_param(
+          socket.assigns.current_url,
+          value,
+          interval_options(),
+          @default_interval
+        )
     )
     |> noreply()
   end

--- a/lib/voyager_web/live/supervision_tree_live.ex
+++ b/lib/voyager_web/live/supervision_tree_live.ex
@@ -8,7 +8,6 @@ defmodule VoyagerWeb.SupervisionTreeLive do
   alias VoyagerWeb.FormSchemas.SupervisionTreeControls
   alias VoyagerWeb.SupervisionTreeLive.Diff
   alias VoyagerWeb.Utils.RefreshInterval
-  alias VoyagerWeb.Utils.URL
 
   @impl true
   def mount(_params, _session, socket) do
@@ -103,17 +102,15 @@ defmodule VoyagerWeb.SupervisionTreeLive do
 
   @impl true
   def handle_event("set_interval", %{"interval" => value}, socket) do
-    param =
-      value
-      |> RefreshInterval.from_value(
-        SupervisionTreeComponents.interval_options(),
-        SupervisionTreeComponents.default_refresh_interval()
-      )
-      |> RefreshInterval.to_param()
-
     socket
     |> push_patch(
-      to: URL.put_query_param(socket.assigns.current_url, RefreshInterval.param(), param)
+      to:
+        RefreshInterval.put_param(
+          socket.assigns.current_url,
+          value,
+          SupervisionTreeComponents.interval_options(),
+          SupervisionTreeComponents.default_refresh_interval()
+        )
     )
     |> noreply()
   end

--- a/lib/voyager_web/live/supervision_tree_live.ex
+++ b/lib/voyager_web/live/supervision_tree_live.ex
@@ -7,6 +7,8 @@ defmodule VoyagerWeb.SupervisionTreeLive do
   alias VoyagerWeb.Components.SupervisionTreeComponents
   alias VoyagerWeb.FormSchemas.SupervisionTreeControls
   alias VoyagerWeb.SupervisionTreeLive.Diff
+  alias VoyagerWeb.Utils.RefreshInterval
+  alias VoyagerWeb.Utils.URL
 
   @impl true
   def mount(_params, _session, socket) do
@@ -44,6 +46,7 @@ defmodule VoyagerWeb.SupervisionTreeLive do
   def handle_params(params, _uri, socket) do
     socket
     |> assign(:params, params)
+    |> apply_refresh_param(params)
     |> apply_params(params)
     |> noreply()
   end
@@ -100,10 +103,18 @@ defmodule VoyagerWeb.SupervisionTreeLive do
 
   @impl true
   def handle_event("set_interval", %{"interval" => value}, socket) do
+    param =
+      value
+      |> RefreshInterval.from_value(
+        SupervisionTreeComponents.interval_options(),
+        SupervisionTreeComponents.default_refresh_interval()
+      )
+      |> RefreshInterval.to_param()
+
     socket
-    |> assign(:refresh_interval, parse_interval(value))
-    |> stop_timer()
-    |> start_timer()
+    |> push_patch(
+      to: URL.put_query_param(socket.assigns.current_url, RefreshInterval.param(), param)
+    )
     |> noreply()
   end
 
@@ -276,6 +287,35 @@ defmodule VoyagerWeb.SupervisionTreeLive do
     start_async(socket, :available_apps, fn -> Remote.list_running_applications(node) end)
   end
 
+  # The interval is routed state: `set_interval` only patches the URL, and the
+  # timer is (re)started from here so a reload or a shared link keeps it.
+  defp apply_refresh_param(socket, params) do
+    interval =
+      RefreshInterval.from_params(
+        params,
+        SupervisionTreeComponents.interval_options(),
+        SupervisionTreeComponents.default_refresh_interval()
+      )
+
+    if interval == socket.assigns.refresh_interval do
+      socket
+    else
+      socket
+      |> assign(:refresh_interval, interval)
+      |> restart_timer()
+    end
+  end
+
+  defp restart_timer(socket) do
+    if connected?(socket) do
+      socket
+      |> stop_timer()
+      |> start_timer()
+    else
+      socket
+    end
+  end
+
   defp apply_params(socket, nil), do: socket
 
   defp apply_params(socket, params) do
@@ -378,15 +418,6 @@ defmodule VoyagerWeb.SupervisionTreeLive do
       interval ->
         timer = Process.send_after(self(), :refresh, interval)
         assign(socket, :refresh_timer, timer)
-    end
-  end
-
-  defp parse_interval("off"), do: nil
-
-  defp parse_interval(value) do
-    case Integer.parse(value) do
-      {ms, ""} when ms > 0 -> ms
-      _ -> nil
     end
   end
 

--- a/lib/voyager_web/utils/refresh_interval.ex
+++ b/lib/voyager_web/utils/refresh_interval.ex
@@ -10,6 +10,8 @@ defmodule VoyagerWeb.Utils.RefreshInterval do
   or hand-crafted URL cannot install an arbitrary timer.
   """
 
+  alias VoyagerWeb.Utils.URL
+
   @param "refresh"
 
   @typedoc "Interval in milliseconds, or `nil` when auto-refresh is off."
@@ -17,9 +19,6 @@ defmodule VoyagerWeb.Utils.RefreshInterval do
 
   @typedoc "`{label, param value}` pairs, as passed to the interval select."
   @type options :: [{String.t(), String.t()}]
-
-  @spec param() :: String.t()
-  def param, do: @param
 
   @doc """
   Reads the interval from `handle_params/3` params, falling back to `default`
@@ -30,12 +29,9 @@ defmodule VoyagerWeb.Utils.RefreshInterval do
     from_value(Map.get(params, @param), options, default)
   end
 
-  @doc """
-  Reads the interval from a single value (e.g. a `<select>` submission),
-  falling back to `default` when it is not one of the offered `options`.
-  """
-  @spec from_value(term(), options(), t()) :: t()
-  def from_value(value, options, default) when is_list(options) do
+  # Reads the interval from a single value (e.g. a `<select>` submission),
+  # falling back to `default` when it is not one of the offered `options`.
+  defp from_value(value, options, default) when is_list(options) do
     case parse(value, options) do
       {:ok, interval} -> interval
       :error -> default
@@ -43,22 +39,46 @@ defmodule VoyagerWeb.Utils.RefreshInterval do
   end
 
   @doc """
-  Renders an interval as its `refresh` param value.
+  Renders an interval as its `refresh` param value. Also drives the `selected`
+  state of the interval select, so the option and the URL cannot drift apart.
   """
   @spec to_param(t()) :: String.t()
   def to_param(nil), do: "off"
   def to_param(interval) when is_integer(interval), do: Integer.to_string(interval)
 
-  defp parse("off", _options), do: {:ok, nil}
+  @doc """
+  Writes a submitted value into `url` as the canonical `refresh` param,
+  preserving every other param. Values that are not offered are stored as
+  `default`, so the URL never carries an interval a view would refuse to honour.
+  """
+  @spec put_param(String.t(), term(), options(), t()) :: String.t()
+  def put_param(url, value, options, default) do
+    param =
+      value
+      |> from_value(options, default)
+      |> to_param()
 
+    URL.put_query_param(url, @param, param)
+  end
+
+  # Only values a view actually offers are honoured — `"off"` included, so a
+  # view without an Off option cannot have auto-refresh disabled from the URL.
   defp parse(value, options) when is_binary(value) do
-    with true <- Enum.any?(options, fn {_label, option} -> option == value end),
-         {interval, ""} when interval > 0 <- Integer.parse(value) do
-      {:ok, interval}
+    if Enum.any?(options, fn {_label, option} -> option == value end) do
+      to_interval(value)
     else
-      _ -> :error
+      :error
     end
   end
 
   defp parse(_value, _options), do: :error
+
+  defp to_interval("off"), do: {:ok, nil}
+
+  defp to_interval(value) do
+    case Integer.parse(value) do
+      {interval, ""} when interval > 0 -> {:ok, interval}
+      _ -> :error
+    end
+  end
 end

--- a/lib/voyager_web/utils/refresh_interval.ex
+++ b/lib/voyager_web/utils/refresh_interval.ex
@@ -1,0 +1,64 @@
+defmodule VoyagerWeb.Utils.RefreshInterval do
+  @moduledoc """
+  Reading and writing the auto-refresh interval of a view.
+
+  The interval lives in the `refresh` query param, so it survives page reloads
+  and can be shared through a link. Values mirror the `<select>` options — the
+  interval in milliseconds, or `"off"` when auto-refresh is disabled.
+
+  Params are validated against the options a view actually offers, so a stale
+  or hand-crafted URL cannot install an arbitrary timer.
+  """
+
+  @param "refresh"
+
+  @typedoc "Interval in milliseconds, or `nil` when auto-refresh is off."
+  @type t :: pos_integer() | nil
+
+  @typedoc "`{label, param value}` pairs, as passed to the interval select."
+  @type options :: [{String.t(), String.t()}]
+
+  @spec param() :: String.t()
+  def param, do: @param
+
+  @doc """
+  Reads the interval from `handle_params/3` params, falling back to `default`
+  when the param is missing or is not one of the offered `options`.
+  """
+  @spec from_params(map(), options(), t()) :: t()
+  def from_params(params, options, default) when is_map(params) do
+    from_value(Map.get(params, @param), options, default)
+  end
+
+  @doc """
+  Reads the interval from a single value (e.g. a `<select>` submission),
+  falling back to `default` when it is not one of the offered `options`.
+  """
+  @spec from_value(term(), options(), t()) :: t()
+  def from_value(value, options, default) when is_list(options) do
+    case parse(value, options) do
+      {:ok, interval} -> interval
+      :error -> default
+    end
+  end
+
+  @doc """
+  Renders an interval as its `refresh` param value.
+  """
+  @spec to_param(t()) :: String.t()
+  def to_param(nil), do: "off"
+  def to_param(interval) when is_integer(interval), do: Integer.to_string(interval)
+
+  defp parse("off", _options), do: {:ok, nil}
+
+  defp parse(value, options) when is_binary(value) do
+    with true <- Enum.any?(options, fn {_label, option} -> option == value end),
+         {interval, ""} when interval > 0 <- Integer.parse(value) do
+      {:ok, interval}
+    else
+      _ -> :error
+    end
+  end
+
+  defp parse(_value, _options), do: :error
+end

--- a/test/voyager_web/live/node_info_live_test.exs
+++ b/test/voyager_web/live/node_info_live_test.exs
@@ -309,6 +309,37 @@ defmodule VoyagerWeb.NodeInfoLiveTest do
       assert has_element?(view, ~s|#refresh-interval option[value="5000"][selected]|)
     end
 
+    test "changing the interval writes it to the query params", %{conn: conn} do
+      stub_erpc(Fakes.node_data())
+
+      {:ok, view, _html} = live(conn, @path)
+      render_async(view)
+
+      view
+      |> form("#refresh-interval-form")
+      |> render_change(%{"interval" => "30000"})
+
+      assert assert_patch(view) =~ "refresh=30000"
+    end
+
+    test "restores the interval from the query params", %{conn: conn} do
+      stub_erpc(Fakes.node_data())
+
+      {:ok, view, _html} = live(conn, @path <> "?refresh=30000")
+      render_async(view)
+
+      assert has_element?(view, ~s|#refresh-interval option[value="30000"][selected]|)
+    end
+
+    test "falls back to the default interval for an unsupported param", %{conn: conn} do
+      stub_erpc(Fakes.node_data())
+
+      {:ok, view, _html} = live(conn, @path <> "?refresh=1")
+      render_async(view)
+
+      assert has_element?(view, ~s|#refresh-interval option[value="off"][selected]|)
+    end
+
     test "enables the JSON snapshot action after the async fetch resolves", %{conn: conn} do
       stub_erpc(Fakes.node_data())
 

--- a/test/voyager_web/live/supervision_tree_live_test.exs
+++ b/test/voyager_web/live/supervision_tree_live_test.exs
@@ -8,6 +8,7 @@ defmodule VoyagerWeb.SupervisionTreeLiveTest do
   import Mox
 
   alias Voyager.Fakes
+  alias VoyagerWeb.Components.SupervisionTreeComponents
 
   @node_name "demo@localhost"
   @path "/node/demo@localhost/supervision-tree"
@@ -248,6 +249,48 @@ defmodule VoyagerWeb.SupervisionTreeLiveTest do
 
       assert render(view) =~ "idle"
       refute has_element?(view, "#supervision-tree-body")
+    end
+
+    test "changing the interval writes it to the query params", %{conn: conn} do
+      {:ok, view, _html} = live(conn, @path)
+      render_async(view)
+
+      view
+      |> form("#refresh-interval-form")
+      |> render_change(%{"interval" => "off"})
+
+      assert assert_patch(view) =~ "refresh=off"
+      assert has_element?(view, ~s|#refresh-interval option[value="off"][selected]|)
+    end
+
+    test "restores the interval from the query params", %{conn: conn} do
+      {:ok, view, _html} = live(conn, @path <> "?refresh=30000")
+      render_async(view)
+
+      assert has_element?(view, ~s|#refresh-interval option[value="30000"][selected]|)
+    end
+
+    test "keeps the other query params when the interval changes", %{conn: conn} do
+      {:ok, view, _html} = live(conn, @path <> "?apps=demo_app")
+      render_async(view)
+
+      view
+      |> form("#refresh-interval-form")
+      |> render_change(%{"interval" => "off"})
+
+      path = assert_patch(view)
+
+      assert path =~ "refresh=off"
+      assert path =~ "apps=demo_app"
+    end
+
+    test "falls back to the default interval for an unsupported param", %{conn: conn} do
+      {:ok, view, _html} = live(conn, @path <> "?refresh=123")
+      render_async(view)
+
+      default = to_string(SupervisionTreeComponents.default_refresh_interval())
+
+      assert has_element?(view, ~s|#refresh-interval option[value="#{default}"][selected]|)
     end
   end
 

--- a/test/voyager_web/utils/refresh_interval_test.exs
+++ b/test/voyager_web/utils/refresh_interval_test.exs
@@ -1,0 +1,53 @@
+defmodule VoyagerWeb.Utils.RefreshIntervalTest do
+  use ExUnit.Case, async: true
+
+  alias VoyagerWeb.Utils.RefreshInterval
+
+  @options [{"Off", "off"}, {"5s", "5000"}, {"30s", "30000"}]
+  @default 5000
+
+  describe "from_params/3" do
+    test "reads an offered interval" do
+      assert RefreshInterval.from_params(%{"refresh" => "30000"}, @options, @default) == 30_000
+    end
+
+    test "reads a disabled auto-refresh" do
+      assert RefreshInterval.from_params(%{"refresh" => "off"}, @options, @default) == nil
+    end
+
+    test "falls back to the default when the param is missing" do
+      assert RefreshInterval.from_params(%{}, @options, @default) == @default
+      assert RefreshInterval.from_params(%{"apps" => "demo"}, @options, @default) == @default
+    end
+
+    test "falls back to the default for intervals that are not offered" do
+      assert RefreshInterval.from_params(%{"refresh" => "1"}, @options, @default) == @default
+      assert RefreshInterval.from_params(%{"refresh" => "-5000"}, @options, @default) == @default
+      assert RefreshInterval.from_params(%{"refresh" => "5000ms"}, @options, @default) == @default
+      assert RefreshInterval.from_params(%{"refresh" => "nope"}, @options, @default) == @default
+      assert RefreshInterval.from_params(%{"refresh" => ["5000"]}, @options, @default) == @default
+    end
+  end
+
+  describe "from_value/3" do
+    test "reads an offered value" do
+      assert RefreshInterval.from_value("30000", @options, @default) == 30_000
+      assert RefreshInterval.from_value("off", @options, @default) == nil
+    end
+
+    test "falls back to the default for a value that is not offered" do
+      assert RefreshInterval.from_value("1", @options, @default) == @default
+      assert RefreshInterval.from_value(nil, @options, @default) == @default
+    end
+  end
+
+  describe "to_param/1" do
+    test "renders an interval" do
+      assert RefreshInterval.to_param(5000) == "5000"
+    end
+
+    test "renders a disabled auto-refresh" do
+      assert RefreshInterval.to_param(nil) == "off"
+    end
+  end
+end

--- a/test/voyager_web/utils/refresh_interval_test.exs
+++ b/test/voyager_web/utils/refresh_interval_test.exs
@@ -27,17 +27,35 @@ defmodule VoyagerWeb.Utils.RefreshIntervalTest do
       assert RefreshInterval.from_params(%{"refresh" => "nope"}, @options, @default) == @default
       assert RefreshInterval.from_params(%{"refresh" => ["5000"]}, @options, @default) == @default
     end
+
+    test "refuses to switch auto-refresh off for a view that offers no Off option" do
+      always_on = [{"5s", "5000"}, {"30s", "30000"}]
+
+      assert RefreshInterval.from_params(%{"refresh" => "off"}, always_on, @default) == @default
+    end
   end
 
-  describe "from_value/3" do
-    test "reads an offered value" do
-      assert RefreshInterval.from_value("30000", @options, @default) == 30_000
-      assert RefreshInterval.from_value("off", @options, @default) == nil
+  describe "put_param/4" do
+    test "writes the value as the canonical param, keeping the others" do
+      url = RefreshInterval.put_param("/node/demo?apps=demo_app", "30000", @options, @default)
+
+      assert url =~ "refresh=30000"
+      assert url =~ "apps=demo_app"
     end
 
-    test "falls back to the default for a value that is not offered" do
-      assert RefreshInterval.from_value("1", @options, @default) == @default
-      assert RefreshInterval.from_value(nil, @options, @default) == @default
+    test "stores the default instead of a value that is not offered" do
+      assert RefreshInterval.put_param("/node/demo", "1", @options, @default) ==
+               "/node/demo?refresh=5000"
+
+      assert RefreshInterval.put_param("/node/demo", nil, @options, @default) ==
+               "/node/demo?refresh=5000"
+    end
+
+    test "stores the default instead of Off for a view that offers no Off option" do
+      always_on = [{"5s", "5000"}, {"30s", "30000"}]
+
+      assert RefreshInterval.put_param("/node/demo", "off", always_on, @default) ==
+               "/node/demo?refresh=5000"
     end
   end
 


### PR DESCRIPTION
Closes VOY-87

## What

Auto-refresh interval in Supervision Tree and Node Info lived only in socket assigns, so every page reload reset it to the default. Now it is routed state, stored in the `refresh` query param.

- New `VoyagerWeb.Utils.RefreshInterval` — reads/writes the `refresh` param (`off` or ms) and validates it against the options the given view actually offers, so a crafted URL (`?refresh=1`) falls back to the default instead of setting an arbitrary timer.
- `set_interval` in both LiveViews only does `push_patch` with the canonical param (via `URL.put_query_param`, so `apps`, `depth`, `sidebar` are preserved); the timer starts from `handle_params/3`.
- `NodeInfoLive` gained `handle_params/3`; `SupervisionTreeLive` gained `apply_refresh_param/2` (timer restarts only when `connected?`).
- `SupervisionTreeComponents.interval_options/0` is now public (+ specs).
- Removed the duplicated `parse_interval/1` from both views.

## Tests

`mix precommit` — 363 passed, credo clean. Added unit tests for the helper plus LiveView tests: writing to the URL, restoring from the URL, preserving other params, and the fallback for an unsupported value.