### PR TITLE
Tests: Isolate persistent_term to fix flaky export tests

### DIFF
--- a/test/support/test_utils.ex
+++ b/test/support/test_utils.ex
@@ -3,6 +3,10 @@ defmodule Voyager.TestUtils do
   Shared test helpers.
   """
 
+  import ExUnit.Callbacks, only: [on_exit: 1]
+
+  @absent {__MODULE__, :absent}
+
   @doc """
   Converts changeset errors into a map of translated messages.
   """
@@ -13,4 +17,34 @@ defmodule Voyager.TestUtils do
       end)
     end)
   end
+
+  @doc """
+  Isolates a `:persistent_term` key for the current test.
+
+  The previous value (or absence) is restored on exit. When `value` is given,
+  it is written before the test runs so assertions do not depend on leftover
+  state from other cases.
+  """
+  def isolate_persistent_term(key) do
+    previous = fetch_persistent_term(key)
+    on_exit(fn -> restore_persistent_term(key, previous) end)
+    :ok
+  end
+
+  def isolate_persistent_term(key, value) do
+    previous = fetch_persistent_term(key)
+    :persistent_term.put(key, value)
+    on_exit(fn -> restore_persistent_term(key, previous) end)
+    :ok
+  end
+
+  defp fetch_persistent_term(key) do
+    case :persistent_term.get(key, @absent) do
+      @absent -> :absent
+      value -> {:ok, value}
+    end
+  end
+
+  defp restore_persistent_term(key, :absent), do: :persistent_term.erase(key)
+  defp restore_persistent_term(key, {:ok, value}), do: :persistent_term.put(key, value)
 end

--- a/test/voyager/node_session_test.exs
+++ b/test/voyager/node_session_test.exs
@@ -1,6 +1,8 @@
 defmodule Voyager.NodeSessionTest do
   use Voyager.DataCase, async: false
 
+  import Voyager.TestUtils, only: [isolate_persistent_term: 1]
+
   alias Voyager.NodeSession
   alias Voyager.NodeSession.Session
 
@@ -39,6 +41,7 @@ defmodule Voyager.NodeSessionTest do
 
   setup do
     previous_state = :sys.get_state(NodeSession)
+    isolate_persistent_term(:connected_via)
     on_exit(fn -> :sys.replace_state(NodeSession, fn _ -> previous_state end) end)
     Phoenix.PubSub.subscribe(Voyager.PubSub, NodeSession.topic())
     :ok

--- a/test/voyager/services/remote_node_connector_test.exs
+++ b/test/voyager/services/remote_node_connector_test.exs
@@ -1,17 +1,15 @@
 defmodule Voyager.Services.RemoteNodeConnectorTest do
   use ExUnit.Case, async: false
 
+  import Voyager.TestUtils, only: [isolate_persistent_term: 2]
+
   alias Voyager.ProxyEpmd
   alias Voyager.Services.RemoteNodeConnector
 
   @moduletag capture_log: true
 
   setup do
-    previous_epmd_module = :persistent_term.get(:voyager_epmd_module, :erl_epmd)
-    :persistent_term.put(:voyager_epmd_module, ProxyEpmd)
-
-    on_exit(fn -> :persistent_term.put(:voyager_epmd_module, previous_epmd_module) end)
-
+    isolate_persistent_term(:voyager_epmd_module, ProxyEpmd)
     :ok
   end
 

--- a/test/voyager/telemetry/handler/export_test.exs
+++ b/test/voyager/telemetry/handler/export_test.exs
@@ -1,12 +1,15 @@
 defmodule Voyager.Telemetry.Handler.ExportTest do
   use Voyager.DataCase, async: false
 
+  import Voyager.TestUtils, only: [isolate_persistent_term: 1, isolate_persistent_term: 2]
+
   alias Voyager.Telemetry.Handler.Export
   alias Voyager.Telemetry.InstallId
 
   setup do
+    isolate_persistent_term({InstallId, :install_id})
+    isolate_persistent_term(:connected_via, nil)
     InstallId.clear_cache()
-    on_exit(&InstallId.clear_cache/0)
     :ok
   end
 

--- a/test/voyager/telemetry/install_id_test.exs
+++ b/test/voyager/telemetry/install_id_test.exs
@@ -1,12 +1,14 @@
 defmodule Voyager.Telemetry.InstallIdTest do
   use Voyager.DataCase, async: false
 
+  import Voyager.TestUtils, only: [isolate_persistent_term: 1]
+
   alias Voyager.Settings
   alias Voyager.Telemetry.InstallId
 
   setup do
+    isolate_persistent_term({InstallId, :install_id})
     InstallId.clear_cache()
-    on_exit(&InstallId.clear_cache/0)
     :ok
   end
 

--- a/test/voyager/telemetry/manager_test.exs
+++ b/test/voyager/telemetry/manager_test.exs
@@ -1,6 +1,8 @@
 defmodule Voyager.Telemetry.ManagerTest do
   use Voyager.DataCase, async: false
 
+  import Voyager.TestUtils, only: [isolate_persistent_term: 1]
+
   alias Voyager.Settings
   alias Voyager.Telemetry
   alias Voyager.Telemetry.Manager
@@ -17,6 +19,8 @@ defmodule Voyager.Telemetry.ManagerTest do
   end
 
   setup do
+    isolate_persistent_term({Manager, :enabled})
+
     on_exit(fn ->
       Application.put_env(:voyager, :terms_accepted, true)
       Manager.set_enabled(true)

--- a/test/voyager_web/live/connect_live_test.exs
+++ b/test/voyager_web/live/connect_live_test.exs
@@ -2,15 +2,18 @@ defmodule VoyagerWeb.ConnectLiveTest do
   use VoyagerWeb.ConnCase, async: false
 
   import Phoenix.LiveViewTest
+  import Voyager.TestUtils, only: [isolate_persistent_term: 1]
 
   alias Voyager.Actions.Connections, as: ConnectionActions
   alias Voyager.Fakes
   alias Voyager.NodeSession
   alias Voyager.Settings
+  alias Voyager.Telemetry.Manager
 
   setup do
     previous_state = :sys.get_state(NodeSession)
     Fakes.put_session(nil)
+    isolate_persistent_term(:connected_via)
 
     on_exit(fn ->
       :sys.replace_state(NodeSession, fn _ -> previous_state end)
@@ -138,6 +141,7 @@ defmodule VoyagerWeb.ConnectLiveTest do
     setup do
       # test.exs locks :terms_accepted so unrelated LiveViews skip the modal.
       # Clear it here so we exercise the real first-launch / DB-backed path.
+      isolate_persistent_term({Manager, :enabled})
       Application.delete_env(:voyager, :terms_accepted)
       on_exit(fn -> Application.put_env(:voyager, :terms_accepted, true) end)
       :ok

--- a/test/voyager_web/live/settings_live_test.exs
+++ b/test/voyager_web/live/settings_live_test.exs
@@ -2,9 +2,11 @@ defmodule VoyagerWeb.SettingsLiveTest do
   use VoyagerWeb.ConnCase, async: false
 
   import Phoenix.LiveViewTest
+  import Voyager.TestUtils, only: [isolate_persistent_term: 1]
 
   alias Voyager.Fakes
   alias Voyager.Settings
+  alias Voyager.Telemetry.Manager
 
   setup do
     previous_state = :sys.get_state(Voyager.NodeSession)
@@ -224,6 +226,7 @@ defmodule VoyagerWeb.SettingsLiveTest do
 
   describe "telemetry settings" do
     setup do
+      isolate_persistent_term({Manager, :enabled})
       on_exit(fn -> Voyager.Telemetry.set_enabled(true) end)
       :ok
     end


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes VOY-174.

`Voyager.Telemetry.Handler.Export.build_payload/3` fills `connected_via` from `NodeSession.cached_connector_name/0` when the event metadata does not include it. That cache lives in `:persistent_term`. `NodeSessionTest` writes `:fake` on connect and only restored GenServer state, so a later `ExportTest` sometimes saw `connected_via: :fake` instead of `nil`.

This adds `Voyager.TestUtils.isolate_persistent_term/1,2` and uses it in every test that reads or writes persistent_term:

- `:connected_via` — `NodeSessionTest`, `ExportTest`, `ConnectLiveTest`
- `{InstallId, :install_id}` — `InstallIdTest`, `ExportTest`
- `{Manager, :enabled}` — `ManagerTest`, `SettingsLiveTest`, `ConnectLiveTest`
- `:voyager_epmd_module` — `RemoteNodeConnectorTest`

Export tests that assert a missing connector now start from a known `nil` cache instead of leftover suite state.

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [VOY-174](https://linear.app/softwaremansion/issue/VOY-174/fix-flaky-tests)

<div><a href="https://cursor.com/agents/bc-1dddeed7-ffb9-4009-9dc4-b6032d9092e8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1dddeed7-ffb9-4009-9dc4-b6032d9092e8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

