### PR TITLE
Feature: Mark locally built apps with a "Dev Build" banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,19 @@ mix assets.deploy
 mix tauri.app
 ```
 
+### Marking local builds
+
+`rel/app/tauri.sh` sources `rel/app/.env` (git-ignored) before building or
+running the desktop app. Setting `VOYAGER_DEV_BUILD` there puts a `Dev Build`
+banner above the topbar, so a locally built app is never mistaken for a release:
+
+```sh
+# rel/app/.env
+VOYAGER_DEV_BUILD=true
+```
+
+CI has no `rel/app/.env`, so published builds never carry the banner.
+
 Before opening a pull request, run:
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -122,9 +122,10 @@ mix tauri.app
 
 ### Marking local builds
 
-`rel/app/tauri.sh` sources `rel/app/.env` (git-ignored) before building or
-running the desktop app. Setting `VOYAGER_DEV_BUILD` there puts a `Dev Build`
-banner above the topbar, so a locally built app is never mistaken for a release:
+`rel/app/tauri.sh` sources `rel/app/.env` (git-ignored, copied from
+[`rel/app/.env.sample`](rel/app/.env.sample)) before building or running the
+desktop app. Setting `VOYAGER_DEV_BUILD` there puts a `Dev Build` banner above
+the topbar, so a locally built app is never mistaken for a release:
 
 ```sh
 # rel/app/.env

--- a/config/config.exs
+++ b/config/config.exs
@@ -6,6 +6,13 @@ config :voyager,
 
 config :voyager, :terms_of_service_url, "https://swmansion.com/legal/voyager/terms-of-service/"
 
+# Marks locally built apps with a "Dev Build" banner. Read at build time rather
+# than in `runtime.exs`, because the bundled desktop app is launched without the
+# shell environment it was built in. `rel/app/tauri.sh` exports this from
+# `rel/app/.env`, a file that only exists on developer machines, so builds made
+# on CI are never marked.
+config :voyager, :dev_build?, System.get_env("VOYAGER_DEV_BUILD") in ~w(1 true)
+
 config :voyager, VoyagerWeb.Endpoint,
   url: [host: "localhost"],
   adapter: Bandit.PhoenixAdapter,

--- a/lib/voyager.ex
+++ b/lib/voyager.ex
@@ -10,4 +10,13 @@ defmodule Voyager do
 
   @spec version() :: String.t()
   def version, do: @version
+
+  @doc """
+  Returns whether the running app came from a local (developer) build.
+
+  Set from the `VOYAGER_DEV_BUILD` environment variable when the app is built —
+  see `config/config.exs`.
+  """
+  @spec dev_build?() :: boolean()
+  def dev_build?, do: Application.get_env(:voyager, :dev_build?, false)
 end

--- a/lib/voyager_web/components/layouts.ex
+++ b/lib/voyager_web/components/layouts.ex
@@ -69,13 +69,36 @@ defmodule VoyagerWeb.Layouts do
   def settings(assigns) do
     ~H"""
     <.flash_group flash={@flash} />
-    <div class="bg-base-200 flex h-screen flex-col overflow-hidden">
+    <div class="bg-base-200 flex h-full flex-col overflow-hidden">
       <VoyagerWeb.Components.Shell.settings_topbar return_to={assigns[:return_to]} />
       <main class="flex-1 overflow-y-auto">
         {@inner_content}
       </main>
     </div>
     <.onboarding_modal show={assigns[:show_onboarding?]} />
+    """
+  end
+
+  @doc """
+  Renders the "Dev Build" banner that tops every page of a locally built app.
+
+  Renders nothing unless `Voyager.dev_build?/0` is true, so released builds
+  never show it.
+  """
+  def dev_banner(assigns) do
+    assigns = assign(assigns, :dev_build?, Voyager.dev_build?())
+
+    ~H"""
+    <%!-- `text-neutral` rather than `text-warning-content`: the latter is tuned
+          for the muted `warning-bg` alert surface and washes out on solid amber. --%>
+    <div
+      :if={@dev_build?}
+      id="dev-build-banner"
+      role="status"
+      class="bg-warning text-neutral tracking-label flex flex-none items-center justify-center gap-1.5 px-4 py-1 text-xs font-semibold uppercase"
+    >
+      <.icon name="icon-circle-alert" class="size-3.5" /> Dev Build
+    </div>
     """
   end
 

--- a/lib/voyager_web/components/layouts/root.html.heex
+++ b/lib/voyager_web/components/layouts/root.html.heex
@@ -163,7 +163,12 @@
     </script>
   </head>
   <body>
-    {@inner_content}
+    <%!-- The banner sits above every layout's own topbar, so page chrome below it
+          sizes to the remaining space rather than to the full viewport. --%>
+    <div class="flex h-full flex-col">
+      <.dev_banner />
+      <div class="min-h-0 flex-1">{@inner_content}</div>
+    </div>
     <%!-- Global target for teleported tooltip popovers (see <.help_tooltip>) --%>
     <div id="tooltip-portal-root"></div>
   </body>

--- a/lib/voyager_web/components/shell.ex
+++ b/lib/voyager_web/components/shell.ex
@@ -16,7 +16,7 @@ defmodule VoyagerWeb.Components.Shell do
 
   def shell(assigns) do
     ~H"""
-    <div class="bg-base-200 flex h-screen flex-col overflow-x-auto overflow-y-hidden">
+    <div class="bg-base-200 flex h-full flex-col overflow-x-auto overflow-y-hidden">
       <div class="min-w-sm flex min-h-0 flex-1 flex-col">
         <.topbar
           active_nav={@active_nav}

--- a/rel/app/.env.sample
+++ b/rel/app/.env.sample
@@ -1,2 +1,4 @@
 TELEMETRY_PUSH_URL=
 TELEMETRY_API_KEY=
+# Set to `true` to mark this build with a "Dev Build" banner.
+VOYAGER_DEV_BUILD=

--- a/rel/app/tauri.sh
+++ b/rel/app/tauri.sh
@@ -43,6 +43,10 @@ main() {
 
   command="${1:-}"
 
+  # Sourced for every command so a local build is configured the same way it is
+  # run. CI checks out no `.env`, which is what keeps released builds clean.
+  load_dotenv "$root_dir/.env"
+
   config="--config"
   # tauri.conf.json keeps resources as an empty list so this per-OS map replaces it.
   config_json="{\"bundle\":{\"resources\":{\"${release_dir}\":\"rel\"}}}"
@@ -53,8 +57,6 @@ main() {
 
   case "$command" in
     dev)
-      load_dotenv "$root_dir/.env"
-      
       (
         cd "$mix_project_dir"
         mix compile
@@ -69,7 +71,6 @@ main() {
       ;;
     app)
       shift
-      load_dotenv "$root_dir/.env"
       mix_release
       bundles_flag=""
       if [ "$os" = "darwin" ]; then
@@ -89,7 +90,8 @@ main() {
   esac
 }
 
-# Export telemetry (and other) vars for `tauri.dev` runtime and for `option_env!` during `tauri.app` compile.
+# Export telemetry, VOYAGER_DEV_BUILD, and other vars for `tauri.dev` runtime and
+# for `option_env!` during `tauri.app` compile.
 load_dotenv() {
   local env_file="$1"
   if [ -f "$env_file" ]; then

--- a/test/voyager_web/components/layouts_test.exs
+++ b/test/voyager_web/components/layouts_test.exs
@@ -1,0 +1,52 @@
+defmodule VoyagerWeb.LayoutsTest do
+  use VoyagerWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+
+  alias VoyagerWeb.Layouts
+
+  setup do
+    previous = Application.get_env(:voyager, :dev_build?)
+    on_exit(fn -> Application.put_env(:voyager, :dev_build?, previous) end)
+    :ok
+  end
+
+  describe "dev_banner/1" do
+    test "renders nothing on a released build" do
+      Application.put_env(:voyager, :dev_build?, false)
+
+      assert render_component(&Layouts.dev_banner/1) =~ ~r/\A\s*\z/
+    end
+
+    test "names the build on a local build" do
+      Application.put_env(:voyager, :dev_build?, true)
+
+      html = render_component(&Layouts.dev_banner/1)
+
+      assert html |> LazyHTML.from_fragment() |> banner_count() == 1
+      assert html =~ "Dev Build"
+    end
+  end
+
+  describe "root layout" do
+    test "tops the page with the banner on a local build", %{conn: conn} do
+      Application.put_env(:voyager, :dev_build?, true)
+
+      assert conn |> render_page() |> banner_count() == 1
+    end
+
+    test "leaves the page unmarked on a released build", %{conn: conn} do
+      Application.put_env(:voyager, :dev_build?, false)
+
+      assert conn |> render_page() |> banner_count() == 0
+    end
+  end
+
+  defp render_page(conn) do
+    conn |> get(~p"/") |> html_response(200) |> LazyHTML.from_document()
+  end
+
+  defp banner_count(document) do
+    document |> LazyHTML.query_by_id("dev-build-banner") |> Enum.count()
+  end
+end

--- a/test/voyager_web/components/layouts_test.exs
+++ b/test/voyager_web/components/layouts_test.exs
@@ -29,21 +29,27 @@ defmodule VoyagerWeb.LayoutsTest do
   end
 
   describe "root layout" do
-    test "tops the page with the banner on a local build", %{conn: conn} do
-      Application.put_env(:voyager, :dev_build?, true)
+    # Every `live_session` brings its own layout, so each is checked against the
+    # shared root that carries the banner.
+    @pages [connect: "/", settings: "/settings"]
 
-      assert conn |> render_page() |> banner_count() == 1
-    end
+    for {name, path} <- @pages do
+      test "tops the #{name} page with the banner on a local build", %{conn: conn} do
+        Application.put_env(:voyager, :dev_build?, true)
 
-    test "leaves the page unmarked on a released build", %{conn: conn} do
-      Application.put_env(:voyager, :dev_build?, false)
+        assert conn |> render_page(unquote(path)) |> banner_count() == 1
+      end
 
-      assert conn |> render_page() |> banner_count() == 0
+      test "leaves the #{name} page unmarked on a released build", %{conn: conn} do
+        Application.put_env(:voyager, :dev_build?, false)
+
+        assert conn |> render_page(unquote(path)) |> banner_count() == 0
+      end
     end
   end
 
-  defp render_page(conn) do
-    conn |> get(~p"/") |> html_response(200) |> LazyHTML.from_document()
+  defp render_page(conn, path) do
+    conn |> get(path) |> html_response(200) |> LazyHTML.from_document()
   end
 
   defp banner_count(document) do

--- a/test/voyager_web/components/layouts_test.exs
+++ b/test/voyager_web/components/layouts_test.exs
@@ -15,16 +15,18 @@ defmodule VoyagerWeb.LayoutsTest do
     test "renders nothing on a released build" do
       Application.put_env(:voyager, :dev_build?, false)
 
-      assert render_component(&Layouts.dev_banner/1) =~ ~r/\A\s*\z/
+      # Emptiness, not just the absence of the banner id: the component must add
+      # no markup at all to a released build.
+      assert render_component(&Layouts.dev_banner/1) |> String.trim() == ""
     end
 
     test "names the build on a local build" do
       Application.put_env(:voyager, :dev_build?, true)
 
-      html = render_component(&Layouts.dev_banner/1)
+      banner = render_banner()
 
-      assert html |> LazyHTML.from_fragment() |> banner_count() == 1
-      assert html =~ "Dev Build"
+      assert Enum.count(banner) == 1
+      assert banner |> LazyHTML.text() |> String.trim() == "Dev Build"
     end
   end
 
@@ -46,6 +48,12 @@ defmodule VoyagerWeb.LayoutsTest do
         assert conn |> render_page(unquote(path)) |> banner_count() == 0
       end
     end
+  end
+
+  defp render_banner do
+    render_component(&Layouts.dev_banner/1)
+    |> LazyHTML.from_fragment()
+    |> LazyHTML.query_by_id("dev-build-banner")
   end
 
   defp render_page(conn, path) do


### PR DESCRIPTION
Closes [VOY-164](https://linear.app/softwaremansion/issue/VOY-164/add-dev-banner).

A locally built desktop app looked exactly like a released one. This adds a strong-colored `Dev Build` banner above the topbar on local builds only.

## How it is switched on

`rel/app/tauri.sh` already sources `rel/app/.env` (git-ignored) for `dev` and `app`; it now does so for every command, so a local build is configured the same way it is run. CI checks out no `.env`, which is what keeps published builds unmarked — no config file or code change is needed to toggle it:

```sh
# rel/app/.env, copied from rel/app/.env.sample
VOYAGER_DEV_BUILD=true
```

The value is read in `config/config.exs` rather than `runtime.exs` on purpose: the bundled desktop app is launched through the OS (`open`), so it does not inherit the shell environment it was built in. Reading it at build time bakes the flag into the release, while `mix phx.server` still picks it up from the environment at boot. Only `1`/`true` enable it, so the blank entry in `.env.sample` reads as off.

## Where the banner lives

It is rendered from the root layout so it tops every page, including connect and settings, which have no app shell. The layouts below it move from `h-screen` to `h-full` so they size to the space left over instead of to the full viewport — verified there is no page overflow with the banner on (`scrollHeight == clientHeight`).

`text-neutral` is used instead of `text-warning-content`, which is tuned for the muted `warning-bg` alert surface and washes out on solid amber; `text-neutral` stays dark in both themes.

## Testing

- `mix precommit` — green on the merged tree (383 tests, plus the Rust suite).
- New `test/voyager_web/components/layouts_test.exs` covers the component in both states and asserts the rendered page carries / omits `#dev-build-banner` on both `/` and `/settings` — one per `live_session`, since each composes its own layout with the shared root.
- Rendered `/` and `/settings` in Chromium in both light and dark themes with the flag on: banner shows above the topbar, contrast holds in both themes, no page overflow.

> [!NOTE]
> The one red `Build and test` run on 4d42126 was an unrelated port race in `Voyager.MCPCase` — [diagnosis here](https://github.com/software-mansion/voyager/pull/200#issuecomment-5454019179). Green again since `main` was merged in.