### PR TITLE
Fix flaky MCP tests colliding on reserved ports

### DIFF
--- a/test/support/mcp_case.ex
+++ b/test/support/mcp_case.ex
@@ -46,10 +46,56 @@ defmodule Voyager.MCPCase do
     end
   end
 
-  @doc "Picks a high ephemeral port unlikely to collide across parallel test files."
+  @reserved_ports __MODULE__.PortReservations
+  @max_port_attempts 50
+
+  @doc """
+  Asks the kernel for a free TCP port and reserves it for this test run.
+
+  Remapping `System.unique_integer/1` into a small range is not unique:
+  remainders collide, and the chosen port may already be bound or sitting in
+  TIME_WAIT. Binding port 0 lets the OS pick a free ephemeral port; a
+  reservation set then prevents parallel callers from being handed the same
+  port after the probe socket is closed.
+  """
   @spec unique_port() :: pos_integer()
   def unique_port do
-    54_000 + rem(System.unique_integer([:positive]), 4_000)
+    ensure_port_reservations()
+    reserve_free_port(@max_port_attempts)
+  end
+
+  defp reserve_free_port(0) do
+    raise "could not reserve a free TCP port"
+  end
+
+  defp reserve_free_port(attempts) do
+    {:ok, socket} = :gen_tcp.listen(0, [:binary, active: false, ip: {127, 0, 0, 1}])
+    {:ok, port} = :inet.port(socket)
+    :ok = :gen_tcp.close(socket)
+
+    if reserve_port?(port) do
+      port
+    else
+      reserve_free_port(attempts - 1)
+    end
+  end
+
+  defp reserve_port?(port) do
+    Agent.get_and_update(@reserved_ports, fn reserved ->
+      if MapSet.member?(reserved, port) do
+        {false, reserved}
+      else
+        {true, MapSet.put(reserved, port)}
+      end
+    end)
+  end
+
+  # Unlinked so the reservation set outlives individual test processes.
+  defp ensure_port_reservations do
+    case Agent.start(fn -> MapSet.new() end, name: @reserved_ports) do
+      {:ok, _pid} -> :ok
+      {:error, {:already_started, _pid}} -> :ok
+    end
   end
 
   @doc false

--- a/test/voyager/mcp/endpoint_manager_test.exs
+++ b/test/voyager/mcp/endpoint_manager_test.exs
@@ -46,8 +46,8 @@ defmodule Voyager.MCP.EndpointManagerTest do
   end
 
   describe "set_port/1" do
-    test "restarts the endpoint on a new port", %{mcp_port: port} do
-      new_port = port + 1
+    test "restarts the endpoint on a new port" do
+      new_port = unique_port()
       assert :ok = MCP.set_port(new_port)
       assert Settings.get(:mcp_port) == new_port
 
@@ -59,27 +59,28 @@ defmodule Voyager.MCP.EndpointManagerTest do
       Application.put_env(:voyager, :mcp_port, port)
       on_exit(fn -> Application.delete_env(:voyager, :mcp_port) end)
 
-      assert {:error, :locked} = MCP.set_port(port + 1)
+      assert {:error, :locked} = MCP.set_port(unique_port())
 
       assert %{alive?: true, url: url} = MCP.info()
       assert url == "http://127.0.0.1:#{port}/mcp"
     end
 
     test "returns {:error, :port_in_use} and keeps the current listener", %{mcp_port: port} do
-      {:ok, socket} = :gen_tcp.listen(port + 1, [:binary, active: false, ip: {127, 0, 0, 1}])
+      busy_port = unique_port()
+      {:ok, socket} = :gen_tcp.listen(busy_port, [:binary, active: false, ip: {127, 0, 0, 1}])
       on_exit(fn -> :gen_tcp.close(socket) end)
 
-      assert {:error, :port_in_use} = MCP.set_port(port + 1)
+      assert {:error, :port_in_use} = MCP.set_port(busy_port)
 
       assert %{alive?: true, url: url} = MCP.info()
       assert url == "http://127.0.0.1:#{port}/mcp"
     end
 
-    test "persists a new port while the listener stays down after toggle", %{mcp_port: port} do
+    test "persists a new port while the listener stays down after toggle" do
       assert {:ok, :stopped} = MCP.toggle()
       assert %{alive?: false} = MCP.info()
 
-      new_port = port + 2
+      new_port = unique_port()
       assert :ok = MCP.set_port(new_port)
       assert Settings.get(:mcp_port) == new_port
 

--- a/test/voyager/mcp_case_test.exs
+++ b/test/voyager/mcp_case_test.exs
@@ -1,0 +1,36 @@
+defmodule Voyager.MCPCaseTest do
+  use ExUnit.Case, async: true
+
+  alias Voyager.MCPCase
+
+  test "unique_port/0 returns a bindable port" do
+    port = MCPCase.unique_port()
+    assert port > 0
+
+    assert {:ok, socket} = :gen_tcp.listen(port, [:binary, active: false, ip: {127, 0, 0, 1}])
+    :ok = :gen_tcp.close(socket)
+  end
+
+  test "unique_port/0 does not reuse a port during the test run" do
+    ports = Enum.map(1..20, fn _ -> MCPCase.unique_port() end)
+    assert ports == Enum.uniq(ports)
+  end
+
+  test "unique_port/0 is unique across concurrent callers" do
+    ports =
+      1..20
+      |> Task.async_stream(fn _ -> MCPCase.unique_port() end, timeout: :infinity)
+      |> Enum.map(fn {:ok, port} -> port end)
+
+    assert ports == Enum.uniq(ports)
+  end
+
+  test "unique_port/0 does not return a port that is already listening" do
+    {:ok, socket} = :gen_tcp.listen(0, [:binary, active: false, ip: {127, 0, 0, 1}])
+    {:ok, busy_port} = :inet.port(socket)
+    on_exit(fn -> :gen_tcp.close(socket) end)
+
+    ports = MapSet.new(Enum.map(1..30, fn _ -> MCPCase.unique_port() end))
+    refute MapSet.member?(ports, busy_port)
+  end
+end

--- a/test/voyager_web/live/settings_live_test.exs
+++ b/test/voyager_web/live/settings_live_test.exs
@@ -141,10 +141,10 @@ defmodule VoyagerWeb.SettingsLiveTest do
       assert has_element?(view, ~s|#mcp-toggle[data-toggle-revision="1"]|)
     end
 
-    test "updates the port", %{conn: conn, mcp_port: port} do
+    test "updates the port", %{conn: conn} do
       {:ok, view, _html} = live(conn, ~p"/settings")
 
-      new_port = port + 1
+      new_port = Voyager.MCPCase.unique_port()
 
       view
       |> form("#mcp-port-form", %{"mcp_port" => %{"port" => to_string(new_port)}})
@@ -155,14 +155,15 @@ defmodule VoyagerWeb.SettingsLiveTest do
       assert render(view) =~ "Running at http://127.0.0.1:#{new_port}/mcp"
     end
 
-    test "shows an error when the port is already in use", %{conn: conn, mcp_port: port} do
-      {:ok, socket} = :gen_tcp.listen(port + 1, [:binary, active: false, ip: {127, 0, 0, 1}])
+    test "shows an error when the port is already in use", %{conn: conn} do
+      busy_port = Voyager.MCPCase.unique_port()
+      {:ok, socket} = :gen_tcp.listen(busy_port, [:binary, active: false, ip: {127, 0, 0, 1}])
       on_exit(fn -> :gen_tcp.close(socket) end)
 
       {:ok, view, _html} = live(conn, ~p"/settings")
 
       view
-      |> form("#mcp-port-form", %{"mcp_port" => %{"port" => to_string(port + 1)}})
+      |> form("#mcp-port-form", %{"mcp_port" => %{"port" => to_string(busy_port)}})
       |> render_submit()
 
       assert render(view) =~ "That port is already in use"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes [VOY-148](https://linear.app/swmansion/issue/VOY-148).

`Voyager.MCP.EndpointManagerTest` flakes on CI when Bandit fails to bind because `unique_port/0` only remapped `System.unique_integer/1` into a 4,000-port window. Remainders collide, and the chosen port may already be bound or sitting in TIME_WAIT — the crash-broadcast test then sees `endpoint: nil`.

This change:

- Asks the kernel for a free ephemeral port (`listen(0)`) instead of guessing
- Remembers reserved ports for the suite so parallel callers cannot reuse one after the probe socket closes
- Stops using `port + 1` / `port + 2` (those neighbors were never checked)
- Adds tests that `unique_port/0` is bindable, unique sequentially and concurrently, and skips a port that is already listening

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [VOY-148](https://linear.app/softwaremansion/issue/VOY-148/mcp-flaky-test)

<div><a href="https://cursor.com/agents/bc-e99f40bc-e246-4b43-8ba6-2d4c4af8b2ab?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e99f40bc-e246-4b43-8ba6-2d4c4af8b2ab&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

