### PR TITLE
Chore: Default the PR review workflow to Opus

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -63,5 +63,5 @@ jobs:
             `track_progress` mode forbids creating new comments — never open a separate one.
             Never post test or placeholder comments.
           claude_args: |
-            ${{ contains(env.TRIGGER_BODY, '@claude review opus') && '--model opus' || '--model sonnet' }}
+            ${{ contains(env.TRIGGER_BODY, '@claude review sonnet') && '--model sonnet' || '--model opus' }}
             --allowedTools "Skill,mcp__github_inline_comment__create_inline_comment,Read,Glob,Grep,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api repos/${{ github.repository }}/pulls/${{ github.event.issue.number || github.event.pull_request.number }}/comments:*)"


### PR DESCRIPTION
## What

`@claude review` now runs the review with `--model opus` by default. `@claude review sonnet` opts into Sonnet.

## Why

Opus gives noticeably better review findings; Sonnet was the default only as a cost saving. Flipping the default keeps the cheaper option available on demand.

## Notes for reviewers

The old `@claude review opus` phrase still triggers a review (it contains `@claude review`) and now simply gets Opus like everything else. No other file referenced the old trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)