### PR TITLE
Add installing voyager_agent on node connect

### DIFF
--- a/lib/voyager/agent.ex
+++ b/lib/voyager/agent.ex
@@ -22,6 +22,10 @@ defmodule Voyager.Agent do
            | {:register_failed, term()}
            | CodeInjector.error_reason()}
 
+  @doc "Minimum OTP release the agent requires on the remote node."
+  @spec min_otp() :: pos_integer()
+  def min_otp, do: @min_otp
+
   @doc """
   Loads the agent on `node` and registers this Voyager node with it.
 

--- a/lib/voyager/agent.ex
+++ b/lib/voyager/agent.ex
@@ -6,20 +6,82 @@ defmodule Voyager.Agent do
   """
 
   alias Voyager.Erpc
+  alias Voyager.NodeSession
+  alias Voyager.Services.CodeInjector
 
   @agent :voyager_agent
+  @agent_source "voyager_agent.erl"
+  @min_otp 27
+  @otp_timeout 5_000
+  @register_timeout 5_000
+
+  @type install_error ::
+          {:agent_install_failed,
+           {:otp_too_old, String.t()}
+           | {:otp_unknown, term()}
+           | {:register_failed, term()}
+           | CodeInjector.error_reason()}
+
+  @doc """
+  Loads the agent on `node` and registers this Voyager node with it.
+
+  The remote OTP release is checked first.
+  """
+  @spec install(node()) :: :ok | {:error, install_error()}
+  def install(node) do
+    path = Path.join(:code.priv_dir(:voyager), @agent_source)
+
+    with :ok <- check_otp(node),
+         {:ok, @agent} <- CodeInjector.load(node, path),
+         {:ok, _pid} <- register(node) do
+      :ok
+    else
+      {:error, reason} -> {:error, {:agent_install_failed, reason}}
+    end
+  end
 
   @doc """
   Calls `:voyager_agent.fun(args...)` on `node`, bounded by `timeout`.
 
-  Returns `{:ok, result}`, or `{:error, reason}` on failure.
-  `{:error, {:remote_exception, :undef}}` usually means the agent is not loaded
-  on the node yet.
+  Returns `{:ok, result}`, or `{:error, reason}` on failure. An `:undef` from
+  the remote means the agent is gone from an already-established connection, so
+  the session is torn down.
   """
   @spec call(node(), atom(), [term()], timeout()) :: {:ok, term()} | {:error, Erpc.erpc_error()}
   def call(node, fun, args, timeout) do
-    {:ok, Erpc.call(node, @agent, fun, args, timeout)}
-  catch
-    kind, reason -> Erpc.format_error(kind, reason)
+    case Erpc.safe_call(node, @agent, fun, args, timeout) do
+      {:error, {:remote_exception, :undef}} = error ->
+        NodeSession.agent_missing(node)
+        error
+
+      result ->
+        result
+    end
   end
+
+  defp register(node) do
+    case Erpc.safe_call(node, @agent, :register, [Node.self()], @register_timeout) do
+      {:ok, {:ok, pid}} -> {:ok, pid}
+      {:ok, {:error, reason}} -> {:error, {:register_failed, reason}}
+      {:ok, other} -> {:error, {:register_failed, other}}
+      {:error, _} = error -> error
+    end
+  end
+
+  defp check_otp(node) do
+    with {:ok, release} <-
+           Erpc.safe_call(node, :erlang, :system_info, [:otp_release], @otp_timeout),
+         {:ok, version} <- parse_release(release) do
+      if version >= @min_otp, do: :ok, else: {:error, {:otp_too_old, to_string(release)}}
+    end
+  end
+
+  defp parse_release(release) when is_list(release) or is_binary(release) do
+    case release |> to_string() |> Integer.parse() do
+      {version, _rest} -> {:ok, version}
+      :error -> {:error, {:otp_unknown, release}}
+    end
+  end
+
+  defp parse_release(release), do: {:error, {:otp_unknown, release}}
 end

--- a/lib/voyager/node_session.ex
+++ b/lib/voyager/node_session.ex
@@ -44,7 +44,7 @@ defmodule Voyager.NodeSession do
   @doc "Connects using an explicit `Voyager.NodeSession.Connector` module."
   @spec connect_via(module(), String.t(), String.t(), keyword()) :: :ok | {:error, term()}
   def connect_via(connector, node_name, cookie, opts \\ []) do
-    GenServer.call(__MODULE__, {:connect, connector, node_name, cookie, opts}, 30_000)
+    GenServer.call(__MODULE__, {:connect, connector, node_name, cookie, opts}, :infinity)
   end
 
   @doc """

--- a/lib/voyager/node_session.ex
+++ b/lib/voyager/node_session.ex
@@ -5,6 +5,7 @@ defmodule Voyager.NodeSession do
 
   use GenServer
 
+  alias Voyager.Agent
   alias Voyager.NodeSession.Connectors.Distribution
 
   @default_connector Distribution
@@ -46,6 +47,16 @@ defmodule Voyager.NodeSession do
     GenServer.call(__MODULE__, {:connect, connector, node_name, cookie, opts}, 30_000)
   end
 
+  @doc """
+  Reports that `node` no longer has the Voyager agent loaded, dropping the
+  session. Asynchronous so agent calls made from inside this GenServer cannot
+  deadlock on it.
+  """
+  @spec agent_missing(node()) :: :ok
+  def agent_missing(node) do
+    GenServer.cast(__MODULE__, {:agent_missing, node})
+  end
+
   @spec disconnect() :: :ok | {:error, :not_connected}
   def disconnect do
     GenServer.call(__MODULE__, :disconnect)
@@ -80,7 +91,7 @@ defmodule Voyager.NodeSession do
   end
 
   def handle_call({:connect, connector, node_name, cookie, opts}, _from, %{session: nil} = state) do
-    case safe_connect(connector, node_name, cookie, opts) do
+    case connect_and_install(connector, node_name, cookie, opts) do
       {:ok, node, meta} ->
         if Node.alive?(), do: Node.monitor(node, true)
         subscribe(connector)
@@ -120,16 +131,9 @@ defmodule Voyager.NodeSession do
   def handle_call(:disconnect, _from, %{session: session} = state) do
     if Node.alive?(), do: Node.monitor(session.node, false)
     session.connector.disconnect(session.node, session.meta)
-    unsubscribe(session.connector)
-    cache_connector_name(nil)
+    new_state = drop_session(state, session, :node_disconnected, "manual disconnect")
 
-    broadcast({:node_disconnected, session.node})
-
-    Voyager.Telemetry.dispatch!("voyager.node.disconnect",
-      metadata: %{reason: "manual disconnect"}
-    )
-
-    {:reply, :ok, %{state | session: nil}}
+    {:reply, :ok, new_state}
   end
 
   def handle_call(:current, _from, state) do
@@ -141,17 +145,31 @@ defmodule Voyager.NodeSession do
   end
 
   @impl GenServer
+  def handle_cast({:agent_missing, node}, %{session: %Session{node: node} = session} = state) do
+    if Node.alive?(), do: Node.monitor(session.node, false)
+    session.connector.disconnect(session.node, session.meta)
+    new_state = drop_session(state, session, :node_disconnected, "agent missing")
+    {:noreply, new_state}
+  end
+
+  def handle_cast(_msg, state) do
+    {:noreply, state}
+  end
+
+  @impl GenServer
   def handle_info({:nodedown, node}, %{session: %Session{node: session_node} = session} = state)
       when node == session_node do
     if Node.alive?(), do: Node.monitor(session.node, false)
     session.connector.disconnect(session.node, session.meta)
-    drop_session(state, session, "node down")
+    new_state = drop_session(state, session, :nodedown, "node down")
+    {:noreply, new_state}
   end
 
   def handle_info(msg, %{session: %Session{connector: connector, meta: meta} = session} = state) do
     if connector.teardown?(msg, meta) do
       if Node.alive?(), do: Node.monitor(session.node, false)
-      drop_session(state, session, "transport down")
+      new_state = drop_session(state, session, :nodedown, "transport down")
+      {:noreply, new_state}
     else
       {:noreply, state}
     end
@@ -161,13 +179,29 @@ defmodule Voyager.NodeSession do
     {:noreply, state}
   end
 
-  defp drop_session(state, session, reason) do
+  defp drop_session(state, session, reason, telemetry_reason) do
     unsubscribe(session.connector)
     cache_connector_name(nil)
 
-    broadcast({:nodedown, session.node})
-    Voyager.Telemetry.dispatch!("voyager.node.disconnect", metadata: %{reason: reason})
-    {:noreply, %{state | session: nil}}
+    broadcast({reason, session.node})
+    Voyager.Telemetry.dispatch!("voyager.node.disconnect", metadata: %{reason: telemetry_reason})
+
+    %{state | session: nil}
+  end
+
+  # Connect owns loading the agent: a node without `:voyager_agent` is not a
+  # usable session, so a failed install fails the whole connect.
+  defp connect_and_install(connector, node_name, cookie, opts) do
+    with {:ok, node, meta} <- safe_connect(connector, node_name, cookie, opts) do
+      case Agent.install(node) do
+        :ok ->
+          {:ok, node, meta}
+
+        {:error, _} = error ->
+          connector.disconnect(node, meta)
+          error
+      end
+    end
   end
 
   defp safe_connect(connector, node_name, cookie, opts) do

--- a/lib/voyager/telemetry/parser.ex
+++ b/lib/voyager/telemetry/parser.ex
@@ -31,6 +31,7 @@ defmodule Voyager.Telemetry.Parser do
     net_kernel_stop
     already_started
     connector_crashed
+    agent_install_failed
   )a
 
   # Option keys are a bounded, non-sensitive set — safe to keep alongside the tag.

--- a/lib/voyager_web/live/connect_live/direct_connect.ex
+++ b/lib/voyager_web/live/connect_live/direct_connect.ex
@@ -242,5 +242,12 @@ defmodule VoyagerWeb.ConnectLive.DirectConnect do
   defp connect_error(:not_distributed), do: "Failed to start Erlang distribution"
   defp connect_error({:net_kernel, _}), do: "Failed to start Erlang distribution"
   defp connect_error({:net_kernel_stop, _}), do: "Failed to restart Erlang distribution"
+
+  defp connect_error({:agent_install_failed, {:otp_too_old, release}}),
+    do: "Node runs OTP #{release} - Voyager requires OTP 27 or newer"
+
+  defp connect_error({:agent_install_failed, _}),
+    do: "Connected, but loading the Voyager agent on the node failed"
+
   defp connect_error(_), do: "Could not connect to node"
 end

--- a/lib/voyager_web/live/connect_live/direct_connect.ex
+++ b/lib/voyager_web/live/connect_live/direct_connect.ex
@@ -244,10 +244,10 @@ defmodule VoyagerWeb.ConnectLive.DirectConnect do
   defp connect_error({:net_kernel_stop, _}), do: "Failed to restart Erlang distribution"
 
   defp connect_error({:agent_install_failed, {:otp_too_old, release}}),
-    do: "Node runs OTP #{release} - Voyager requires OTP 27 or newer"
+    do: "Node runs OTP #{release} - Voyager requires OTP #{Voyager.Agent.min_otp()} or newer"
 
   defp connect_error({:agent_install_failed, _}),
-    do: "Connected, but loading the Voyager agent on the node failed"
+    do: "Could not load the Voyager agent on the node"
 
   defp connect_error(_), do: "Could not connect to node"
 end

--- a/lib/voyager_web/live/connect_live/ssh_connect.ex
+++ b/lib/voyager_web/live/connect_live/ssh_connect.ex
@@ -463,5 +463,11 @@ defmodule VoyagerWeb.ConnectLive.SshConnect do
   defp ssh_connect_error(:unexpected_exit),
     do: {:node_name, "Connection attempt failed unexpectedly"}
 
+  defp ssh_connect_error({:agent_install_failed, {:otp_too_old, release}}),
+    do: {:node_name, "Node runs OTP #{release} - Voyager requires OTP 27 or newer"}
+
+  defp ssh_connect_error({:agent_install_failed, _}),
+    do: {:node_name, "Connected, but loading the Voyager agent on the node failed"}
+
   defp ssh_connect_error(_), do: {:node_name, "Could not connect to remote node"}
 end

--- a/lib/voyager_web/live/connect_live/ssh_connect.ex
+++ b/lib/voyager_web/live/connect_live/ssh_connect.ex
@@ -464,10 +464,12 @@ defmodule VoyagerWeb.ConnectLive.SshConnect do
     do: {:node_name, "Connection attempt failed unexpectedly"}
 
   defp ssh_connect_error({:agent_install_failed, {:otp_too_old, release}}),
-    do: {:node_name, "Node runs OTP #{release} - Voyager requires OTP 27 or newer"}
+    do:
+      {:node_name,
+       "Node runs OTP #{release} - Voyager requires OTP #{Voyager.Agent.min_otp()} or newer"}
 
   defp ssh_connect_error({:agent_install_failed, _}),
-    do: {:node_name, "Connected, but loading the Voyager agent on the node failed"}
+    do: {:node_name, "Could not load the Voyager agent on the node"}
 
   defp ssh_connect_error(_), do: {:node_name, "Could not connect to remote node"}
 end

--- a/test/voyager/agent_test.exs
+++ b/test/voyager/agent_test.exs
@@ -5,8 +5,33 @@ defmodule Voyager.AgentTest do
 
   alias Voyager.Agent
   alias Voyager.Erpc
+  alias Voyager.NodeSession
+  alias Voyager.NodeSession.Session
 
   @agent_module :voyager_agent
+
+  defmodule FakeConnector do
+    @moduledoc false
+    @behaviour Voyager.NodeSession.Connector
+
+    @impl true
+    def name, do: :fake
+
+    @impl true
+    def connect(_node_name, _cookie, _opts), do: {:error, :unsupported}
+
+    @impl true
+    def disconnect(node, meta) do
+      send(meta.test_pid, {:connector_disconnect, node})
+      :ok
+    end
+
+    @impl true
+    def subscriptions, do: []
+
+    @impl true
+    def teardown?(_msg, _meta), do: false
+  end
 
   setup :verify_on_exit!
 
@@ -94,13 +119,36 @@ defmodule Voyager.AgentTest do
       assert {:ok, {[], 0}} = Agent.call(:target@nohost, :proc_top, [1], 1_000)
     end
 
-    test "translates a missing agent into an :undef error" do
+    test "translates a missing agent into an :undef error and drops the session" do
+      node = :target@nohost
+      seed_session(node)
+      Phoenix.PubSub.subscribe(Voyager.PubSub, NodeSession.topic())
+
       expect(Voyager.ErpcMock, :call, fn _node, @agent_module, :proc_top, [1], _timeout ->
         :erlang.error({:exception, :undef, []})
       end)
 
-      assert {:error, {:remote_exception, :undef}} =
-               Agent.call(:target@nohost, :proc_top, [1], 1_000)
+      assert {:error, {:remote_exception, :undef}} = Agent.call(node, :proc_top, [1], 1_000)
+
+      assert_receive {:connector_disconnect, ^node}
+      assert_receive {:node_disconnected, ^node}
+      refute NodeSession.connected?()
     end
+  end
+
+  defp seed_session(node) do
+    previous_state = :sys.get_state(NodeSession)
+    on_exit(fn -> :sys.replace_state(NodeSession, fn _ -> previous_state end) end)
+
+    session = %Session{
+      node: node,
+      node_name: to_string(node),
+      cookie: "secret",
+      connected_at: DateTime.utc_now(),
+      connector: FakeConnector,
+      meta: %{test_pid: self()}
+    }
+
+    :sys.replace_state(NodeSession, &Map.put(&1, :session, session))
   end
 end

--- a/test/voyager/agent_test.exs
+++ b/test/voyager/agent_test.exs
@@ -1,0 +1,106 @@
+defmodule Voyager.AgentTest do
+  use ExUnit.Case, async: false
+
+  import Mox
+
+  alias Voyager.Agent
+  alias Voyager.Erpc
+
+  @agent_module :voyager_agent
+
+  setup :verify_on_exit!
+
+  describe "install/1" do
+    setup do
+      on_exit(fn ->
+        case Process.whereis(@agent_module) do
+          nil ->
+            :ok
+
+          pid ->
+            ref = Process.monitor(pid)
+            Process.exit(pid, :kill)
+            assert_receive {:DOWN, ^ref, :process, ^pid, _reason}
+        end
+
+        :code.purge(@agent_module)
+        :code.delete(@agent_module)
+        :code.purge(@agent_module)
+      end)
+
+      :ok
+    end
+
+    test "refuses a node older than OTP 27 without sending any code" do
+      expect(Voyager.ErpcMock, :call, fn _node, :erlang, :system_info, [:otp_release], _timeout ->
+        ~c"26"
+      end)
+
+      assert {:error, {:agent_install_failed, {:otp_too_old, "26"}}} =
+               Agent.install(:target@nohost)
+
+      refute Code.loaded?(@agent_module)
+    end
+
+    test "reports an unparseable OTP release" do
+      expect(Voyager.ErpcMock, :call, fn _node, :erlang, :system_info, [:otp_release], _timeout ->
+        :unknown
+      end)
+
+      assert {:error, {:agent_install_failed, {:otp_unknown, :unknown}}} =
+               Agent.install(:target@nohost)
+    end
+
+    test "wraps a failed register" do
+      expect(Voyager.ErpcMock, :call, fn _node, :erlang, :system_info, [:otp_release], _timeout ->
+        ~c"27"
+      end)
+
+      stub(Voyager.ErpcMock, :call, fn node, mod, fun, args, timeout ->
+        case {mod, fun} do
+          {@agent_module, :register} -> {:error, :unavailable}
+          _ -> Erpc.Impl.call(node, mod, fun, args, timeout)
+        end
+      end)
+
+      assert {:error, {:agent_install_failed, {:register_failed, :unavailable}}} =
+               Agent.install(Node.self())
+    end
+
+    test "loads and registers the agent on a reachable node" do
+      previous_erpc = Application.get_env(:voyager, :erpc)
+      Application.put_env(:voyager, :erpc, Erpc.Impl)
+      on_exit(fn -> Application.put_env(:voyager, :erpc, previous_erpc) end)
+
+      assert :ok = Agent.install(Node.self())
+      assert :sys.get_state(@agent_module) == {:state, %{Node.self() => true}}
+    end
+
+    test "surfaces a transport failure" do
+      expect(Voyager.ErpcMock, :call, fn _node, :erlang, :system_info, [:otp_release], _timeout ->
+        :erlang.error({:erpc, :noconnection})
+      end)
+
+      assert {:error, {:agent_install_failed, :noconnection}} = Agent.install(:target@nohost)
+    end
+  end
+
+  describe "call/4" do
+    test "returns the remote result" do
+      expect(Voyager.ErpcMock, :call, fn _node, @agent_module, :proc_top, [1], _timeout ->
+        {[], 0}
+      end)
+
+      assert {:ok, {[], 0}} = Agent.call(:target@nohost, :proc_top, [1], 1_000)
+    end
+
+    test "translates a missing agent into an :undef error" do
+      expect(Voyager.ErpcMock, :call, fn _node, @agent_module, :proc_top, [1], _timeout ->
+        :erlang.error({:exception, :undef, []})
+      end)
+
+      assert {:error, {:remote_exception, :undef}} =
+               Agent.call(:target@nohost, :proc_top, [1], 1_000)
+    end
+  end
+end

--- a/test/voyager/node_session_test.exs
+++ b/test/voyager/node_session_test.exs
@@ -189,7 +189,7 @@ defmodule Voyager.NodeSessionTest do
   end
 
   describe "agent_missing/1" do
-    test "drops the session and broadcasts :nodedown" do
+    test "drops the session and broadcasts :node_disconnected" do
       :ok =
         NodeSession.connect_via(FakeConnector, "demo@localhost", "secret", test_pid: self())
 

--- a/test/voyager/node_session_test.exs
+++ b/test/voyager/node_session_test.exs
@@ -4,6 +4,8 @@ defmodule Voyager.NodeSessionTest do
   alias Voyager.NodeSession
   alias Voyager.NodeSession.Session
 
+  @agent_module :voyager_agent
+
   defmodule FakeConnector do
     @moduledoc false
     @behaviour Voyager.NodeSession.Connector
@@ -16,7 +18,7 @@ defmodule Voyager.NodeSessionTest do
       case Keyword.get(opts, :fail) do
         nil ->
           meta = %{test_pid: Keyword.fetch!(opts, :test_pid), ref: Keyword.get(opts, :ref)}
-          {:ok, Node.self(), meta}
+          {:ok, Keyword.get(opts, :node, Node.self()), meta}
 
         reason ->
           {:error, reason}
@@ -39,8 +41,34 @@ defmodule Voyager.NodeSessionTest do
 
   setup do
     previous_state = :sys.get_state(NodeSession)
-    on_exit(fn -> :sys.replace_state(NodeSession, fn _ -> previous_state end) end)
+    previous_erpc = Application.get_env(:voyager, :erpc)
+    # Connect now injects the agent, so the real transport has to run against this node.
+    Application.put_env(:voyager, :erpc, Voyager.Erpc.Impl)
+
+    on_exit(fn ->
+      :sys.replace_state(NodeSession, fn _ -> previous_state end)
+      Application.put_env(:voyager, :erpc, previous_erpc)
+      stop_agent()
+    end)
+
     Phoenix.PubSub.subscribe(Voyager.PubSub, NodeSession.topic())
+    :ok
+  end
+
+  defp stop_agent do
+    case Process.whereis(@agent_module) do
+      nil ->
+        :ok
+
+      pid ->
+        ref = Process.monitor(pid)
+        Process.exit(pid, :kill)
+        assert_receive {:DOWN, ^ref, :process, ^pid, _reason}
+    end
+
+    :code.purge(@agent_module)
+    :code.delete(@agent_module)
+    :code.purge(@agent_module)
     :ok
   end
 
@@ -58,6 +86,31 @@ defmodule Voyager.NodeSessionTest do
 
       assert NodeSession.connected?()
       assert_receive {:node_connected, ^node}
+    end
+
+    test "loads and registers the agent on the connected node" do
+      assert :ok =
+               NodeSession.connect_via(FakeConnector, "demo@localhost", "secret",
+                 test_pid: self()
+               )
+
+      assert Code.loaded?(@agent_module)
+      assert is_pid(Process.whereis(@agent_module))
+      assert :sys.get_state(@agent_module) == {:state, %{Node.self() => true}}
+    end
+
+    test "fails the connect and tears down the connector when the agent cannot be installed" do
+      unreachable = :"voyager-nonexistent@nohost"
+
+      assert {:error, {:agent_install_failed, :noconnection}} =
+               NodeSession.connect_via(FakeConnector, "demo@localhost", "secret",
+                 test_pid: self(),
+                 node: unreachable
+               )
+
+      assert_receive {:connector_disconnect, ^unreachable}
+      refute NodeSession.connected?()
+      refute_received {:node_connected, _}
     end
 
     test "rejects a second connect attempt while already connected" do
@@ -132,6 +185,30 @@ defmodule Voyager.NodeSessionTest do
       assert_receive {:connector_disconnect, ^node}
       assert_receive {:nodedown, ^node}
       refute NodeSession.connected?()
+    end
+  end
+
+  describe "agent_missing/1" do
+    test "drops the session and broadcasts :nodedown" do
+      :ok =
+        NodeSession.connect_via(FakeConnector, "demo@localhost", "secret", test_pid: self())
+
+      node = Node.self()
+      NodeSession.agent_missing(node)
+
+      assert_receive {:connector_disconnect, ^node}
+      assert_receive {:node_disconnected, ^node}
+      refute NodeSession.connected?()
+    end
+
+    test "ignores a node that is not the current session" do
+      :ok =
+        NodeSession.connect_via(FakeConnector, "demo@localhost", "secret", test_pid: self())
+
+      NodeSession.agent_missing(:other@nohost)
+      _ = :sys.get_state(NodeSession)
+
+      assert NodeSession.connected?()
     end
   end
 


### PR DESCRIPTION
Connect now owns loading the agent: after a successful distribution connect, NodeSession loads :voyager_agent on the remote node and calls `register/1`. If that fails, the connect fails cleanly — no half-connected session.

- `Agent.install/1`: OTP-27 check first (older ⇒ connect refused with an explicit version message, no code sent), then load, then register(Node.self()).
- `Agent.call/4` drops the session when a remote call returns `:undef` (agent gone mid-connection).
- Error messages in both connect forms; `agent_install_failed` allowlisted in telemetry.