### PR TITLE
Add ETS match-spec search

### DIFF
--- a/lib/voyager/services/ets/fetch.ex
+++ b/lib/voyager/services/ets/fetch.ex
@@ -3,14 +3,15 @@ defmodule Voyager.Services.Ets.Fetch do
   Fetches ETS record payloads from a remote node via `:voyager_agent`.
 
   Table metadata stays on `Voyager.Services.Ets.Remote`. These reads call
-  `:ets_select_chunk/4` and `:ets_lookup/3` on the agent. A missing agent is
-  `:undef` and drops the session. Truncation and the heap cap run on the
-  target. Each record is walked independently with the caller's term `budget`
-  (see `Voyager.Agent.default_budget/0`).
+  `:ets_select_chunk/4`, `:ets_select_spec/5`, and `:ets_lookup/3` on the agent.
+  A missing agent is `:undef` and drops the session. Truncation and the heap cap
+  run on the target. Each record is walked independently with the caller's term
+  `budget` (see `Voyager.Agent.default_budget/0`).
 
-  A continuation that crossed ETF must be repaired on the target against
-  `[{:"$1", [], [:"$1"]}]` before `ets:select/1`. `badarg` (private table,
-  unrepaired continuation, out-of-range budget) is `{:error, :cannot_read}`.
+  A continuation that crossed ETF must be repaired on the target against the
+  same match spec used for the page (`[{:"$1", [], [:"$1"]}]` for match-all)
+  before `ets:select/1`. `badarg` (private table, bad spec, unrepaired
+  continuation, out-of-range budget) is `{:error, :cannot_read}`.
   """
 
   alias Voyager.Agent
@@ -57,6 +58,40 @@ defmodule Voyager.Services.Ets.Fetch do
   end
 
   def select_chunk(_node, _table, _limit, _budget, _continuation, _timeout),
+    do: {:error, :invalid_table}
+
+  @spec select_spec(
+          node(),
+          TableId.t(),
+          term(),
+          pos_integer(),
+          non_neg_integer(),
+          term() | nil,
+          timeout()
+        ) ::
+          {:ok, chunk()} | {:error, term()}
+  def select_spec(
+        node,
+        table,
+        spec,
+        limit,
+        budget \\ @budget,
+        continuation \\ nil,
+        timeout \\ Agent.default_timeout()
+      )
+
+  def select_spec(node, table, spec, limit, budget, continuation, timeout)
+      when TableId.is_table_id(table) and is_integer(limit) and limit > 0 do
+    cont = continuation || :undefined
+    fetch_chunk(node, :ets_select_spec, [table, spec, limit, budget, cont], timeout)
+  end
+
+  def select_spec(_node, table, _spec, _limit, _budget, _continuation, _timeout)
+      when TableId.is_table_id(table) do
+    {:error, :invalid_limit}
+  end
+
+  def select_spec(_node, _table, _spec, _limit, _budget, _continuation, _timeout),
     do: {:error, :invalid_table}
 
   @spec lookup(node(), TableId.t(), lookup_key(), non_neg_integer(), timeout()) ::

--- a/lib/voyager/services/ets/remote.ex
+++ b/lib/voyager/services/ets/remote.ex
@@ -73,6 +73,20 @@ defmodule Voyager.Services.Ets.Remote do
 
   def info(_node, _table, _timeout), do: {:error, :invalid_table}
 
+  @spec keypos(node(), TableId.t(), timeout()) :: {:ok, pos_integer()} | {:error, term()}
+  def keypos(node, table, timeout \\ Erpc.default_timeout())
+
+  def keypos(node, table, timeout) when TableId.is_table_id(table) do
+    case Erpc.safe_call(node, :ets, :info, [table, :keypos], timeout) do
+      {:ok, keypos} when is_integer(keypos) and keypos >= 1 -> {:ok, keypos}
+      {:ok, :undefined} -> {:error, :not_found}
+      {:ok, _} -> {:error, :invalid_response}
+      {:error, _} = err -> err
+    end
+  end
+
+  def keypos(_node, _table, _timeout), do: {:error, :invalid_table}
+
   defp fetch_infos(_node, [], _timeout), do: {:ok, []}
 
   defp fetch_infos(node, ids, timeout) do

--- a/lib/voyager/services/ets/search.ex
+++ b/lib/voyager/services/ets/search.ex
@@ -2,8 +2,12 @@ defmodule Voyager.Services.Ets.Search do
   @moduledoc """
   Compiles key-prefix / field-equals queries into source ETS match specs.
 
-  Never evals user or LLM strings. `{:key_eq, _}` is `Fetch.lookup/5`.
-  Prefix and element queries go through `Fetch.select_spec/7`.
+  Never evals user or LLM strings. Prefix and element queries go through
+  `Fetch.select_spec/7` and honour `Fetch.limit()` plus continuation.
+  `{:key_eq, _}` is a single-shot `Fetch.lookup/5`: the limit is still one of
+  `Fetch.chunk_sizes/0` but is not a page size, and continuation is ignored.
+  A bag/duplicate_bag key returns every object in one reply, or
+  `:heap_limit_exceeded` if the worker heap cap trips.
   The spec sent on the wire is a source MS, not `:ets.match_spec_compile/1`.
   """
 
@@ -50,7 +54,7 @@ defmodule Voyager.Services.Ets.Search do
           node(),
           TableId.t(),
           query(),
-          pos_integer(),
+          Fetch.limit(),
           non_neg_integer(),
           term() | nil,
           timeout()
@@ -68,7 +72,8 @@ defmodule Voyager.Services.Ets.Search do
 
   def chunk(node, table, query, limit, budget, continuation, timeout)
       when TableId.is_table_id(table) and is_integer(budget) and budget >= 0 do
-    with :ok <- validate_query(query) do
+    with :ok <- validate_query(query),
+         :ok <- validate_limit(limit) do
       run_query(node, table, query, limit, budget, continuation, timeout)
     end
   end
@@ -94,6 +99,10 @@ defmodule Voyager.Services.Ets.Search do
   end
 
   defp validate_query(_), do: {:error, :invalid_query}
+
+  defp validate_limit(limit) do
+    if limit in Fetch.chunk_sizes(), do: :ok, else: {:error, :invalid_limit}
+  end
 
   defp run_query(node, table, {:key_eq, value}, _limit, budget, _continuation, timeout) do
     Fetch.lookup(node, table, value, budget, timeout)

--- a/lib/voyager/services/ets/search.ex
+++ b/lib/voyager/services/ets/search.ex
@@ -7,8 +7,8 @@ defmodule Voyager.Services.Ets.Search do
   """
 
   alias Voyager.Agent
-  alias Voyager.Erpc
   alias Voyager.Services.Ets.Fetch
+  alias Voyager.Services.Ets.Remote
   alias Voyager.Services.Ets.TableId
 
   require TableId
@@ -96,18 +96,9 @@ defmodule Voyager.Services.Ets.Search do
 
   defp validate_query(_), do: {:error, :invalid_query}
 
-  defp keypos_for(node, table, {:key_eq, _}, timeout), do: fetch_keypos(node, table, timeout)
-  defp keypos_for(node, table, {:key_prefix, _}, timeout), do: fetch_keypos(node, table, timeout)
+  defp keypos_for(node, table, {:key_eq, _}, timeout), do: Remote.keypos(node, table, timeout)
+  defp keypos_for(node, table, {:key_prefix, _}, timeout), do: Remote.keypos(node, table, timeout)
   defp keypos_for(_node, _table, {:element_eq, _, _}, _timeout), do: {:ok, 1}
-
-  defp fetch_keypos(node, table, timeout) do
-    case Erpc.safe_call(node, :ets, :info, [table, :keypos], timeout) do
-      {:ok, keypos} when is_integer(keypos) and keypos >= 1 -> {:ok, keypos}
-      {:ok, :undefined} -> {:error, :not_found}
-      {:ok, _} -> {:error, :invalid_response}
-      {:error, _} = err -> err
-    end
-  end
 
   defp eq_query(pos, value) do
     if valid_scalar?(value) do

--- a/lib/voyager/services/ets/search.ex
+++ b/lib/voyager/services/ets/search.ex
@@ -113,7 +113,7 @@ defmodule Voyager.Services.Ets.Search do
 
   defp eq_query(pos, value) do
     if valid_scalar?(value) do
-      {:ok, [{:"$1", [{:"=:=", {:element, pos, :"$1"}, value}], [:"$1"]}]}
+      {:ok, [{:"$1", [{:"=:=", {:element, pos, :"$1"}, {:const, value}}], [:"$1"]}]}
     else
       {:error, :invalid_query}
     end

--- a/lib/voyager/services/ets/search.ex
+++ b/lib/voyager/services/ets/search.ex
@@ -87,7 +87,7 @@ defmodule Voyager.Services.Ets.Search do
   end
 
   defp validate_query({:key_prefix, prefix}) when is_binary(prefix) do
-    prefix_query(1, prefix) |> query_ok()
+    if valid_prefix?(prefix), do: :ok, else: {:error, :invalid_query}
   end
 
   defp validate_query({:element_eq, index, value}) when is_integer(index) and index >= 1 do
@@ -95,9 +95,6 @@ defmodule Voyager.Services.Ets.Search do
   end
 
   defp validate_query(_), do: {:error, :invalid_query}
-
-  defp query_ok({:ok, _}), do: :ok
-  defp query_ok({:error, _} = err), do: err
 
   defp keypos_for(node, table, {:key_eq, _}, timeout), do: fetch_keypos(node, table, timeout)
   defp keypos_for(node, table, {:key_prefix, _}, timeout), do: fetch_keypos(node, table, timeout)
@@ -120,30 +117,29 @@ defmodule Voyager.Services.Ets.Search do
   end
 
   defp prefix_query(pos, prefix) do
-    size = byte_size(prefix)
+    if valid_prefix?(prefix) do
+      size = byte_size(prefix)
+      key = {:element, pos, :"$1"}
 
-    cond do
-      size == 0 ->
-        {:error, :invalid_query}
-
-      size > @max_prefix_bytes ->
-        {:error, :invalid_query}
-
-      true ->
-        key = {:element, pos, :"$1"}
-
-        {:ok,
-         [
-           {:"$1",
-            [
-              {:is_binary, key},
-              {:>=, {:byte_size, key}, size},
-              {:"=:=", {:binary_part, key, 0, size}, prefix}
-            ], [:"$1"]}
-         ]}
+      {:ok,
+       [
+         {:"$1",
+          [
+            {:is_binary, key},
+            {:>=, {:byte_size, key}, size},
+            {:"=:=", {:binary_part, key, 0, size}, prefix}
+          ], [:"$1"]}
+       ]}
+    else
+      {:error, :invalid_query}
     end
   end
 
   defp valid_scalar?(value) when is_atom(value) or is_integer(value) or is_binary(value), do: true
   defp valid_scalar?(_), do: false
+
+  defp valid_prefix?(prefix) when is_binary(prefix) do
+    size = byte_size(prefix)
+    size > 0 and size <= @max_prefix_bytes
+  end
 end

--- a/lib/voyager/services/ets/search.ex
+++ b/lib/voyager/services/ets/search.ex
@@ -115,7 +115,13 @@ defmodule Voyager.Services.Ets.Search do
     end
   end
 
-  defp keypos_for(node, table, {:key_prefix, _}, timeout), do: Remote.keypos(node, table, timeout)
+  defp keypos_for(node, table, {:key_prefix, _}, timeout) do
+    case Remote.keypos(node, table, timeout) do
+      {:error, :not_found} -> {:error, :cannot_read}
+      other -> other
+    end
+  end
+
   defp keypos_for(_node, _table, {:element_eq, _, _}, _timeout), do: {:ok, 1}
 
   defp eq_query(pos, value) do

--- a/lib/voyager/services/ets/search.ex
+++ b/lib/voyager/services/ets/search.ex
@@ -3,11 +3,8 @@ defmodule Voyager.Services.Ets.Search do
   Compiles key-prefix / field-equals queries into source ETS match specs.
 
   Never evals user or LLM strings. Prefix and element queries go through
-  `Fetch.select_spec/7` and honour `Fetch.limit()` plus continuation.
-  `{:key_eq, _}` is a single-shot `Fetch.lookup/5`: the limit is still one of
-  `Fetch.chunk_sizes/0` but is not a page size, and continuation is ignored.
-  A bag/duplicate_bag key returns every object in one reply, or
-  `:heap_limit_exceeded` if the worker heap cap trips.
+  `Fetch.select_spec/7`. `{:key_eq, _}` is a single-shot `Fetch.lookup/5`:
+  the limit is not a page size, and continuation is ignored.
   The spec sent on the wire is a source MS, not `:ets.match_spec_compile/1`.
   """
 
@@ -54,7 +51,7 @@ defmodule Voyager.Services.Ets.Search do
           node(),
           TableId.t(),
           query(),
-          Fetch.limit(),
+          pos_integer(),
           non_neg_integer(),
           term() | nil,
           timeout()
@@ -100,9 +97,8 @@ defmodule Voyager.Services.Ets.Search do
 
   defp validate_query(_), do: {:error, :invalid_query}
 
-  defp validate_limit(limit) do
-    if limit in Fetch.chunk_sizes(), do: :ok, else: {:error, :invalid_limit}
-  end
+  defp validate_limit(limit) when is_integer(limit) and limit > 0, do: :ok
+  defp validate_limit(_limit), do: {:error, :invalid_limit}
 
   defp run_query(node, table, {:key_eq, value}, _limit, budget, _continuation, timeout) do
     Fetch.lookup(node, table, value, budget, timeout)

--- a/lib/voyager/services/ets/search.ex
+++ b/lib/voyager/services/ets/search.ex
@@ -7,8 +7,8 @@ defmodule Voyager.Services.Ets.Search do
   """
 
   alias Voyager.Agent
+  alias Voyager.Erpc
   alias Voyager.Services.Ets.Fetch
-  alias Voyager.Services.Ets.Remote
   alias Voyager.Services.Ets.TableId
 
   require TableId
@@ -101,8 +101,9 @@ defmodule Voyager.Services.Ets.Search do
   defp keypos_for(_node, _table, {:element_eq, _, _}, _timeout), do: {:ok, 1}
 
   defp fetch_keypos(node, table, timeout) do
-    case Remote.info(node, table, timeout) do
-      {:ok, %{keypos: keypos}} when is_integer(keypos) and keypos >= 1 -> {:ok, keypos}
+    case Erpc.safe_call(node, :ets, :info, [table, :keypos], timeout) do
+      {:ok, keypos} when is_integer(keypos) and keypos >= 1 -> {:ok, keypos}
+      {:ok, :undefined} -> {:error, :not_found}
       {:ok, _} -> {:error, :invalid_response}
       {:error, _} = err -> err
     end

--- a/lib/voyager/services/ets/search.ex
+++ b/lib/voyager/services/ets/search.ex
@@ -1,0 +1,149 @@
+defmodule Voyager.Services.Ets.Search do
+  @moduledoc """
+  Compiles key-prefix / field-equals queries into source ETS match specs.
+
+  Never evals user or LLM strings. Records go through `Fetch.select_spec/7`.
+  The spec sent on the wire is a source MS, not `:ets.match_spec_compile/1`.
+  """
+
+  alias Voyager.Agent
+  alias Voyager.Services.Ets.Fetch
+  alias Voyager.Services.Ets.Remote
+  alias Voyager.Services.Ets.TableId
+
+  require TableId
+
+  @max_prefix_bytes 512
+  @budget Agent.default_budget()
+
+  @type scalar :: atom() | integer() | binary()
+
+  @type query ::
+          {:key_eq, scalar()}
+          | {:key_prefix, binary()}
+          | {:element_eq, pos_integer(), scalar()}
+
+  @type spec :: [{term(), [term()], [term()]}]
+
+  @type chunk :: Fetch.chunk()
+
+  @spec compile(query(), pos_integer()) :: {:ok, spec()} | {:error, :invalid_query}
+  def compile(query, keypos \\ 1)
+
+  def compile({:key_eq, value}, keypos) when is_integer(keypos) and keypos >= 1 do
+    eq_query(keypos, value)
+  end
+
+  def compile({:key_prefix, prefix}, keypos)
+      when is_integer(keypos) and keypos >= 1 and is_binary(prefix) do
+    prefix_query(keypos, prefix)
+  end
+
+  def compile({:element_eq, index, value}, _keypos) when is_integer(index) and index >= 1 do
+    eq_query(index, value)
+  end
+
+  def compile(_query, _keypos), do: {:error, :invalid_query}
+
+  @spec chunk(
+          node(),
+          TableId.t(),
+          query(),
+          pos_integer(),
+          non_neg_integer(),
+          term() | nil,
+          timeout()
+        ) ::
+          {:ok, chunk()} | {:error, term()}
+  def chunk(
+        node,
+        table,
+        query,
+        limit,
+        budget \\ @budget,
+        continuation \\ nil,
+        timeout \\ Agent.default_timeout()
+      )
+
+  def chunk(node, table, query, limit, budget, continuation, timeout)
+      when TableId.is_table_id(table) and is_integer(budget) and budget >= 0 do
+    with :ok <- validate_query(query),
+         {:ok, keypos} <- keypos_for(node, table, query, timeout),
+         {:ok, spec} <- compile(query, keypos) do
+      Fetch.select_spec(node, table, spec, limit, budget, continuation, timeout)
+    end
+  end
+
+  def chunk(_node, table, _query, _limit, _budget, _continuation, _timeout)
+      when TableId.is_table_id(table) do
+    {:error, :invalid_budget}
+  end
+
+  def chunk(_node, _table, _query, _limit, _budget, _continuation, _timeout),
+    do: {:error, :invalid_table}
+
+  defp validate_query({:key_eq, value}) do
+    if valid_scalar?(value), do: :ok, else: {:error, :invalid_query}
+  end
+
+  defp validate_query({:key_prefix, prefix}) when is_binary(prefix) do
+    prefix_query(1, prefix) |> query_ok()
+  end
+
+  defp validate_query({:element_eq, index, value}) when is_integer(index) and index >= 1 do
+    if valid_scalar?(value), do: :ok, else: {:error, :invalid_query}
+  end
+
+  defp validate_query(_), do: {:error, :invalid_query}
+
+  defp query_ok({:ok, _}), do: :ok
+  defp query_ok({:error, _} = err), do: err
+
+  defp keypos_for(node, table, {:key_eq, _}, timeout), do: fetch_keypos(node, table, timeout)
+  defp keypos_for(node, table, {:key_prefix, _}, timeout), do: fetch_keypos(node, table, timeout)
+  defp keypos_for(_node, _table, {:element_eq, _, _}, _timeout), do: {:ok, 1}
+
+  defp fetch_keypos(node, table, timeout) do
+    case Remote.info(node, table, timeout) do
+      {:ok, %{keypos: keypos}} when is_integer(keypos) and keypos >= 1 -> {:ok, keypos}
+      {:ok, _} -> {:error, :invalid_response}
+      {:error, _} = err -> err
+    end
+  end
+
+  defp eq_query(pos, value) do
+    if valid_scalar?(value) do
+      {:ok, [{:"$1", [{:"=:=", {:element, pos, :"$1"}, value}], [:"$1"]}]}
+    else
+      {:error, :invalid_query}
+    end
+  end
+
+  defp prefix_query(pos, prefix) do
+    size = byte_size(prefix)
+
+    cond do
+      size == 0 ->
+        {:error, :invalid_query}
+
+      size > @max_prefix_bytes ->
+        {:error, :invalid_query}
+
+      true ->
+        key = {:element, pos, :"$1"}
+
+        {:ok,
+         [
+           {:"$1",
+            [
+              {:is_binary, key},
+              {:>=, {:byte_size, key}, size},
+              {:"=:=", {:binary_part, key, 0, size}, prefix}
+            ], [:"$1"]}
+         ]}
+    end
+  end
+
+  defp valid_scalar?(value) when is_atom(value) or is_integer(value) or is_binary(value), do: true
+  defp valid_scalar?(_), do: false
+end

--- a/lib/voyager/services/ets/search.ex
+++ b/lib/voyager/services/ets/search.ex
@@ -10,7 +10,6 @@ defmodule Voyager.Services.Ets.Search do
 
   alias Voyager.Agent
   alias Voyager.Services.Ets.Fetch
-  alias Voyager.Services.Ets.Remote
   alias Voyager.Services.Ets.TableId
 
   require TableId
@@ -52,6 +51,7 @@ defmodule Voyager.Services.Ets.Search do
           TableId.t(),
           query(),
           pos_integer(),
+          pos_integer(),
           non_neg_integer(),
           term() | nil,
           timeout()
@@ -61,26 +61,28 @@ defmodule Voyager.Services.Ets.Search do
         node,
         table,
         query,
+        keypos,
         limit,
         budget \\ @budget,
         continuation \\ nil,
         timeout \\ Agent.default_timeout()
       )
 
-  def chunk(node, table, query, limit, budget, continuation, timeout)
+  def chunk(node, table, query, keypos, limit, budget, continuation, timeout)
       when TableId.is_table_id(table) and is_integer(budget) and budget >= 0 do
     with :ok <- validate_query(query),
+         :ok <- validate_keypos(keypos),
          :ok <- validate_limit(limit) do
-      run_query(node, table, query, limit, budget, continuation, timeout)
+      run_query(node, table, query, keypos, limit, budget, continuation, timeout)
     end
   end
 
-  def chunk(_node, table, _query, _limit, _budget, _continuation, _timeout)
+  def chunk(_node, table, _query, _keypos, _limit, _budget, _continuation, _timeout)
       when TableId.is_table_id(table) do
     {:error, :invalid_budget}
   end
 
-  def chunk(_node, _table, _query, _limit, _budget, _continuation, _timeout),
+  def chunk(_node, _table, _query, _keypos, _limit, _budget, _continuation, _timeout),
     do: {:error, :invalid_table}
 
   defp validate_query({:key_eq, value}) do
@@ -100,25 +102,18 @@ defmodule Voyager.Services.Ets.Search do
   defp validate_limit(limit) when is_integer(limit) and limit > 0, do: :ok
   defp validate_limit(_limit), do: {:error, :invalid_limit}
 
-  defp run_query(node, table, {:key_eq, value}, _limit, budget, _continuation, timeout) do
+  defp validate_keypos(keypos) when is_integer(keypos) and keypos >= 1, do: :ok
+  defp validate_keypos(_keypos), do: {:error, :invalid_keypos}
+
+  defp run_query(node, table, {:key_eq, value}, _keypos, _limit, budget, _continuation, timeout) do
     Fetch.lookup(node, table, value, budget, timeout)
   end
 
-  defp run_query(node, table, query, limit, budget, continuation, timeout) do
-    with {:ok, keypos} <- keypos_for(node, table, query, timeout),
-         {:ok, spec} <- compile(query, keypos) do
+  defp run_query(node, table, query, keypos, limit, budget, continuation, timeout) do
+    with {:ok, spec} <- compile(query, keypos) do
       Fetch.select_spec(node, table, spec, limit, budget, continuation, timeout)
     end
   end
-
-  defp keypos_for(node, table, {:key_prefix, _}, timeout) do
-    case Remote.keypos(node, table, timeout) do
-      {:error, :not_found} -> {:error, :cannot_read}
-      other -> other
-    end
-  end
-
-  defp keypos_for(_node, _table, {:element_eq, _, _}, _timeout), do: {:ok, 1}
 
   defp eq_query(pos, value) do
     if valid_scalar?(value) do

--- a/lib/voyager/services/ets/search.ex
+++ b/lib/voyager/services/ets/search.ex
@@ -2,7 +2,8 @@ defmodule Voyager.Services.Ets.Search do
   @moduledoc """
   Compiles key-prefix / field-equals queries into source ETS match specs.
 
-  Never evals user or LLM strings. Records go through `Fetch.select_spec/7`.
+  Never evals user or LLM strings. `{:key_eq, _}` is `Fetch.lookup/5`.
+  Prefix and element queries go through `Fetch.select_spec/7`.
   The spec sent on the wire is a source MS, not `:ets.match_spec_compile/1`.
   """
 
@@ -67,10 +68,8 @@ defmodule Voyager.Services.Ets.Search do
 
   def chunk(node, table, query, limit, budget, continuation, timeout)
       when TableId.is_table_id(table) and is_integer(budget) and budget >= 0 do
-    with :ok <- validate_query(query),
-         {:ok, keypos} <- keypos_for(node, table, query, timeout),
-         {:ok, spec} <- compile(query, keypos) do
-      Fetch.select_spec(node, table, spec, limit, budget, continuation, timeout)
+    with :ok <- validate_query(query) do
+      run_query(node, table, query, limit, budget, continuation, timeout)
     end
   end
 
@@ -96,7 +95,17 @@ defmodule Voyager.Services.Ets.Search do
 
   defp validate_query(_), do: {:error, :invalid_query}
 
-  defp keypos_for(node, table, {:key_eq, _}, timeout), do: Remote.keypos(node, table, timeout)
+  defp run_query(node, table, {:key_eq, value}, _limit, budget, _continuation, timeout) do
+    Fetch.lookup(node, table, value, budget, timeout)
+  end
+
+  defp run_query(node, table, query, limit, budget, continuation, timeout) do
+    with {:ok, keypos} <- keypos_for(node, table, query, timeout),
+         {:ok, spec} <- compile(query, keypos) do
+      Fetch.select_spec(node, table, spec, limit, budget, continuation, timeout)
+    end
+  end
+
   defp keypos_for(node, table, {:key_prefix, _}, timeout), do: Remote.keypos(node, table, timeout)
   defp keypos_for(_node, _table, {:element_eq, _, _}, _timeout), do: {:ok, 1}
 

--- a/priv/voyager_agent.erl
+++ b/priv/voyager_agent.erl
@@ -7,7 +7,7 @@
 -export([proc_top/5]).
 -export([proc_links/2, proc_monitors/2, proc_monitored_by/2]).
 -export([proc_dictionary/3, proc_messages/3, proc_label/2, proc_state/3]).
--export([ets_select_chunk/4, ets_lookup/3]).
+-export([ets_select_chunk/4, ets_lookup/3, ets_select_spec/5]).
 %% gen_server callbacks
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2,
          code_change/3]).
@@ -496,7 +496,7 @@ with_bounded_heap(Fun) ->
     end.
 
 %% =====================================================================
-%% ETS RECORDS - Match-all select / lookup with on-node truncation.
+%% ETS RECORDS - Match-all / match-spec select / lookup with on-node truncation.
 %% =====================================================================
 %%
 %% Exported functions, not handle_call, so a peek cannot block register
@@ -514,8 +514,21 @@ with_bounded_heap(Fun) ->
                           {ok, ets_chunk()}.
 ets_select_chunk(Table, Limit, Budget, Cont)
     when is_integer(Budget), Budget >= 0, is_integer(Limit), Limit >= 0 ->
-    with_bounded_heap(fun() -> do_select(Table, Limit, Budget, Cont) end);
+    with_bounded_heap(fun() -> do_select(Table, ?MATCH_ALL, Limit, Budget, Cont) end);
 ets_select_chunk(_Table, _Limit, _Budget, _Cont) ->
+    erlang:error(badarg).
+
+-spec ets_select_spec(ets:tab(), term(), pos_integer(), non_neg_integer(), term()) ->
+                         {ok, ets_chunk()}.
+ets_select_spec(Table, Spec, Limit, Budget, Cont)
+    when is_integer(Budget), Budget >= 0, is_integer(Limit), Limit >= 0 ->
+    case valid_spec(Spec) of
+        true ->
+            with_bounded_heap(fun() -> do_select(Table, Spec, Limit, Budget, Cont) end);
+        false ->
+            erlang:error(badarg)
+    end;
+ets_select_spec(_Table, _Spec, _Limit, _Budget, _Cont) ->
     erlang:error(badarg).
 
 -spec ets_lookup(ets:tab(), term(), non_neg_integer()) -> {ok, ets_chunk()}.
@@ -524,12 +537,17 @@ ets_lookup(Table, Key, Budget) when is_integer(Budget), Budget >= 0 ->
 ets_lookup(_Table, _Key, _Budget) ->
     erlang:error(badarg).
 
-do_select(Table, Limit, Budget, undefined) ->
-    wrap_select(ets:select(Table, ?MATCH_ALL, Limit), Budget);
-do_select(_Table, _Limit, Budget, Cont) ->
+do_select(Table, Spec, Limit, Budget, undefined) ->
+    wrap_select(ets:select(Table, Spec, Limit), Budget);
+do_select(_Table, Spec, _Limit, Budget, Cont) ->
     wrap_select(ets:select(
-                    ets:repair_continuation(Cont, ?MATCH_ALL)),
+                    ets:repair_continuation(Cont, Spec)),
                 Budget).
+
+valid_spec([{_Head, Guards, Body}]) when is_list(Guards), is_list(Body) ->
+    true;
+valid_spec(_) ->
+    false.
 
 wrap_select('$end_of_table', _Budget) ->
     wrap_records([], undefined, 0);

--- a/test/voyager/services/ets/fetch_test.exs
+++ b/test/voyager/services/ets/fetch_test.exs
@@ -215,6 +215,89 @@ defmodule Voyager.Services.Ets.FetchTest do
     end
   end
 
+  describe "select_spec/7" do
+    @spec_ms [{:"$1", [{:"=:=", {:element, 1, :"$1"}, :k}], [:"$1"]}]
+
+    test "calls :voyager_agent.ets_select_spec/5 with the budget and :undefined for a nil continuation" do
+      test = self()
+      cont = make_ref()
+
+      expect(Voyager.ErpcMock, :call, fn node, :voyager_agent, :ets_select_spec, args, timeout ->
+        send(test, {:called, node, args, timeout})
+        ok_chunk([{:k, 1}], cont)
+      end)
+
+      assert {:ok, chunk} = Fetch.select_spec(@node, :t, @spec_ms, 10, @budget, nil, @timeout)
+      assert chunk.records == [{:k, 1}]
+      assert chunk.continuation == cont
+      refute chunk.truncated?
+      refute Map.has_key?(chunk, :via)
+
+      assert_received {:called, @node, [:t, @spec_ms, 10, @budget, :undefined], @timeout}
+    end
+
+    test "does not retry a missing agent export as :ets.select" do
+      test = self()
+
+      expect(Voyager.ErpcMock, :call, fn _node, mod, fun, _args, _timeout ->
+        send(test, {:called, mod, fun})
+        :erlang.error({:exception, :undef, []})
+      end)
+
+      assert {:error, {:remote_exception, :undef}} =
+               Fetch.select_spec(@node, :t, @spec_ms, 10, @budget, nil, @timeout)
+
+      assert_received {:called, :voyager_agent, :ets_select_spec}
+      refute_received {:called, :ets, _}
+    end
+
+    test "maps remote badarg to :cannot_read" do
+      expect(Voyager.ErpcMock, :call, fn @node, :voyager_agent, :ets_select_spec, _, _ ->
+        :erlang.error({:exception, :badarg, []})
+      end)
+
+      assert {:error, :cannot_read} =
+               Fetch.select_spec(@node, :t, @spec_ms, 10, @budget, nil, @timeout)
+    end
+
+    test "passes a remote heap kill through untouched" do
+      expect(Voyager.ErpcMock, :call, fn @node, :voyager_agent, :ets_select_spec, _, _ ->
+        exit({:signal, :killed})
+      end)
+
+      assert {:error, {:remote_exit, {:signal, :killed}}} =
+               Fetch.select_spec(@node, :t, @spec_ms, 10, @budget, nil, @timeout)
+    end
+
+    test "rejects a non-positive or non-integer limit without touching the remote" do
+      assert {:error, :invalid_limit} =
+               Fetch.select_spec(@node, :t, @spec_ms, 0, @budget, nil, @timeout)
+
+      assert {:error, :invalid_limit} =
+               Fetch.select_spec(@node, :t, @spec_ms, :ten, @budget, nil, @timeout)
+    end
+
+    test "rejects a handle that is not an atom or reference without touching the remote" do
+      assert {:error, :invalid_table} =
+               Fetch.select_spec(@node, self(), @spec_ms, 10, @budget, nil, @timeout)
+    end
+
+    test "defaults the budget and timeout" do
+      timeout = Agent.default_timeout()
+
+      expect(Voyager.ErpcMock, :call, fn @node,
+                                         :voyager_agent,
+                                         :ets_select_spec,
+                                         [:t, @spec_ms, 10, @budget, :undefined],
+                                         ^timeout ->
+        ok_chunk([])
+      end)
+
+      assert {:ok, %{records: [], continuation: nil, truncated?: false}} =
+               Fetch.select_spec(@node, :t, @spec_ms, 10)
+    end
+  end
+
   defp ok_chunk(records, continuation \\ :undefined, truncated \\ false) do
     {:ok, %{records: records, continuation: continuation, truncated: truncated}}
   end

--- a/test/voyager/services/ets/remote_test.exs
+++ b/test/voyager/services/ets/remote_test.exs
@@ -252,6 +252,32 @@ defmodule Voyager.Services.Ets.RemoteTest do
     end
   end
 
+  describe "keypos/3" do
+    test "fetches :ets.info/2 for :keypos" do
+      expect(Voyager.ErpcMock, :call, fn @node, :ets, :info, [:t, :keypos], @timeout -> 2 end)
+
+      assert {:ok, 2} = Remote.keypos(@node, :t, @timeout)
+    end
+
+    test "returns :not_found when the table is gone" do
+      expect(Voyager.ErpcMock, :call, fn @node, :ets, :info, [:t, :keypos], @timeout ->
+        :undefined
+      end)
+
+      assert {:error, :not_found} = Remote.keypos(@node, :t, @timeout)
+    end
+
+    test "returns :invalid_response when keypos is not a positive integer" do
+      expect(Voyager.ErpcMock, :call, fn @node, :ets, :info, [:t, :keypos], @timeout -> :oops end)
+
+      assert {:error, :invalid_response} = Remote.keypos(@node, :t, @timeout)
+    end
+
+    test "rejects a handle that is not an atom or reference without touching the remote" do
+      assert {:error, :invalid_table} = Remote.keypos(@node, self(), @timeout)
+    end
+  end
+
   defp stub_list(ids, word_size, infos) do
     expect(Voyager.ErpcMock, :call, fn @node, :ets, :all, [], @timeout -> ids end)
 

--- a/test/voyager/services/ets/search_test.exs
+++ b/test/voyager/services/ets/search_test.exs
@@ -124,15 +124,15 @@ defmodule Voyager.Services.Ets.SearchTest do
     end
 
     test "key_prefix compiles using table keypos" do
-      stub_info(1)
+      stub_info(2)
 
       spec =
         [
           {:"$1",
            [
-             {:is_binary, {:element, 1, :"$1"}},
-             {:>=, {:byte_size, {:element, 1, :"$1"}}, 3},
-             {:"=:=", {:binary_part, {:element, 1, :"$1"}, 0, 3}, <<"alp">>}
+             {:is_binary, {:element, 2, :"$1"}},
+             {:>=, {:byte_size, {:element, 2, :"$1"}}, 3},
+             {:"=:=", {:binary_part, {:element, 2, :"$1"}, 0, 3}, <<"alp">>}
            ], [:"$1"]}
         ]
 
@@ -141,13 +141,13 @@ defmodule Voyager.Services.Ets.SearchTest do
                                          :ets_select_spec,
                                          [:t, ^spec, 10, @budget, :undefined],
                                          @timeout ->
-        ok_chunk([{<<"alpha">>, 1}])
+        ok_chunk([{1, <<"alpha">>}])
       end)
 
       assert {:ok, chunk} =
                Search.chunk(@node, :t, {:key_prefix, <<"alp">>}, 10, @budget, nil, @timeout)
 
-      assert chunk.records == [{<<"alpha">>, 1}]
+      assert chunk.records == [{1, <<"alpha">>}]
       refute Map.has_key?(chunk, :via)
       refute chunk.truncated?
     end

--- a/test/voyager/services/ets/search_test.exs
+++ b/test/voyager/services/ets/search_test.exs
@@ -75,34 +75,42 @@ defmodule Voyager.Services.Ets.SearchTest do
     end
   end
 
-  describe "chunk/7" do
+  describe "chunk/8" do
     test "rejects an invalid query without a remote call" do
       assert {:error, :invalid_query} =
-               Search.chunk(@node, :t, "[{:'$1', [], [:'$1']}]", 10, @budget, nil, @timeout)
+               Search.chunk(@node, :t, "[{:'$1', [], [:'$1']}]", 1, 10, @budget, nil, @timeout)
 
       assert {:error, :invalid_query} =
-               Search.chunk(@node, :t, {:key_eq, {1, 2}}, 10, @budget, nil, @timeout)
+               Search.chunk(@node, :t, {:key_eq, {1, 2}}, 1, 10, @budget, nil, @timeout)
 
       assert {:error, :invalid_query} =
-               Search.chunk(@node, :t, {:key_prefix, <<>>}, 10, @budget, nil, @timeout)
+               Search.chunk(@node, :t, {:key_prefix, <<>>}, 1, 10, @budget, nil, @timeout)
     end
 
     test "rejects a handle that is not an atom or reference without a remote call" do
       assert {:error, :invalid_table} =
-               Search.chunk(@node, self(), {:key_eq, :k}, 10, @budget, nil, @timeout)
+               Search.chunk(@node, self(), {:key_eq, :k}, 1, 10, @budget, nil, @timeout)
     end
 
     test "rejects a negative budget without a remote call" do
       assert {:error, :invalid_budget} =
-               Search.chunk(@node, :t, {:key_eq, :k}, 10, -1, nil, @timeout)
+               Search.chunk(@node, :t, {:key_eq, :k}, 1, 10, -1, nil, @timeout)
     end
 
     test "rejects a non-positive or non-integer limit without a remote call" do
       assert {:error, :invalid_limit} =
-               Search.chunk(@node, :t, {:key_eq, :k}, 0, @budget, nil, @timeout)
+               Search.chunk(@node, :t, {:key_eq, :k}, 1, 0, @budget, nil, @timeout)
 
       assert {:error, :invalid_limit} =
-               Search.chunk(@node, :t, {:element_eq, 2, :v}, :ten, @budget, nil, @timeout)
+               Search.chunk(@node, :t, {:element_eq, 2, :v}, 1, :ten, @budget, nil, @timeout)
+    end
+
+    test "rejects a non-positive or non-integer keypos without a remote call" do
+      assert {:error, :invalid_keypos} =
+               Search.chunk(@node, :t, {:key_prefix, <<"ab">>}, 0, 10, @budget, nil, @timeout)
+
+      assert {:error, :invalid_keypos} =
+               Search.chunk(@node, :t, {:key_eq, :k}, :one, 10, @budget, nil, @timeout)
     end
 
     test "key_eq looks up through the agent without fetching table info" do
@@ -115,7 +123,7 @@ defmodule Voyager.Services.Ets.SearchTest do
       end)
 
       assert {:ok, chunk} =
-               Search.chunk(@node, :t, {:key_eq, :the_key}, 10, @budget, nil, @timeout)
+               Search.chunk(@node, :t, {:key_eq, :the_key}, 1, 10, @budget, nil, @timeout)
 
       assert chunk.records == [{1, :the_key}]
       refute Map.has_key?(chunk, :via)
@@ -123,9 +131,7 @@ defmodule Voyager.Services.Ets.SearchTest do
       refute chunk.truncated?
     end
 
-    test "key_prefix compiles using table keypos" do
-      stub_info(2)
-
+    test "key_prefix compiles using the given keypos" do
       spec =
         [
           {:"$1",
@@ -145,7 +151,7 @@ defmodule Voyager.Services.Ets.SearchTest do
       end)
 
       assert {:ok, chunk} =
-               Search.chunk(@node, :t, {:key_prefix, <<"alp">>}, 10, @budget, nil, @timeout)
+               Search.chunk(@node, :t, {:key_prefix, <<"alp">>}, 2, 10, @budget, nil, @timeout)
 
       assert chunk.records == [{1, <<"alpha">>}]
       refute Map.has_key?(chunk, :via)
@@ -164,7 +170,7 @@ defmodule Voyager.Services.Ets.SearchTest do
       end)
 
       assert {:ok, chunk} =
-               Search.chunk(@node, :t, {:element_eq, 2, :v}, 10, @budget, nil, @timeout)
+               Search.chunk(@node, :t, {:element_eq, 2, :v}, 1, 10, @budget, nil, @timeout)
 
       assert chunk.records == [{:a, :v}]
     end
@@ -182,20 +188,11 @@ defmodule Voyager.Services.Ets.SearchTest do
       end)
 
       assert {:ok, chunk} =
-               Search.chunk(@node, :t, {:element_eq, 1, :k}, 10, @budget, cont, @timeout)
+               Search.chunk(@node, :t, {:element_eq, 1, :k}, 1, 10, @budget, cont, @timeout)
 
       assert chunk.records == []
       assert chunk.continuation == nil
       refute chunk.truncated?
-    end
-
-    test "maps a missing table on key prefix to :cannot_read" do
-      expect(Voyager.ErpcMock, :call, fn @node, :ets, :info, [:t, :keypos], @timeout ->
-        :undefined
-      end)
-
-      assert {:error, :cannot_read} =
-               Search.chunk(@node, :t, {:key_prefix, <<"ab">>}, 10, @budget, nil, @timeout)
     end
 
     test "does not retry a missing agent export as :ets.select" do
@@ -208,7 +205,7 @@ defmodule Voyager.Services.Ets.SearchTest do
       end)
 
       assert {:error, {:remote_exception, :undef}} =
-               Search.chunk(@node, :t, {:element_eq, 2, :v}, 10, @budget, nil, @timeout)
+               Search.chunk(@node, :t, {:element_eq, 2, :v}, 1, 10, @budget, nil, @timeout)
 
       assert_received {:called, :voyager_agent, :ets_select_spec,
                        [:t, ^spec, 10, @budget, :undefined]}
@@ -219,11 +216,5 @@ defmodule Voyager.Services.Ets.SearchTest do
 
   defp ok_chunk(records, continuation \\ :undefined, truncated \\ false) do
     {:ok, %{records: records, continuation: continuation, truncated: truncated}}
-  end
-
-  defp stub_info(keypos) do
-    expect(Voyager.ErpcMock, :call, fn @node, :ets, :info, [:t, :keypos], @timeout ->
-      keypos
-    end)
   end
 end

--- a/test/voyager/services/ets/search_test.exs
+++ b/test/voyager/services/ets/search_test.exs
@@ -40,6 +40,18 @@ defmodule Voyager.Services.Ets.SearchTest do
       assert {:ok, false} = :ets.test_ms({:k, :other}, spec)
     end
 
+    test "key_eq treats :\"$1\" as a literal, not a match variable" do
+      assert {:ok, spec} = Search.compile({:key_eq, :"$1"}, 1)
+      assert {:ok, {:"$1", 1}} = :ets.test_ms({:"$1", 1}, spec)
+      assert {:ok, false} = :ets.test_ms({:k, 1}, spec)
+    end
+
+    test "key_eq treats :\"$2\" as a literal, not an unbound match variable" do
+      assert {:ok, spec} = Search.compile({:key_eq, :"$2"}, 1)
+      assert {:ok, {:"$2", 1}} = :ets.test_ms({:"$2", 1}, spec)
+      assert {:ok, false} = :ets.test_ms({:"$1", 1}, spec)
+    end
+
     test "rejects a match-spec string" do
       assert {:error, :invalid_query} = Search.compile("fn x -> true end")
       assert {:error, :invalid_query} = Search.compile("[{:'$1', [], [:'$1']}]")
@@ -88,7 +100,7 @@ defmodule Voyager.Services.Ets.SearchTest do
     test "key_eq compiles using table keypos and selects through the agent" do
       stub_info(keypos: 2)
 
-      spec = [{:"$1", [{:"=:=", {:element, 2, :"$1"}, :the_key}], [:"$1"]}]
+      spec = [{:"$1", [{:"=:=", {:element, 2, :"$1"}, {:const, :the_key}}], [:"$1"]}]
 
       expect(Voyager.ErpcMock, :call, fn @node,
                                          :voyager_agent,
@@ -137,7 +149,7 @@ defmodule Voyager.Services.Ets.SearchTest do
     end
 
     test "element_eq does not fetch table info" do
-      spec = [{:"$1", [{:"=:=", {:element, 2, :"$1"}, :v}], [:"$1"]}]
+      spec = [{:"$1", [{:"=:=", {:element, 2, :"$1"}, {:const, :v}}], [:"$1"]}]
 
       expect(Voyager.ErpcMock, :call, fn @node,
                                          :voyager_agent,
@@ -154,7 +166,7 @@ defmodule Voyager.Services.Ets.SearchTest do
     end
 
     test "passes a raw continuation through to the agent" do
-      spec = [{:"$1", [{:"=:=", {:element, 1, :"$1"}, :k}], [:"$1"]}]
+      spec = [{:"$1", [{:"=:=", {:element, 1, :"$1"}, {:const, :k}}], [:"$1"]}]
       cont = make_ref()
 
       expect(Voyager.ErpcMock, :call, fn @node,
@@ -182,7 +194,7 @@ defmodule Voyager.Services.Ets.SearchTest do
 
     test "does not retry a missing agent export as :ets.select" do
       test = self()
-      spec = [{:"$1", [{:"=:=", {:element, 2, :"$1"}, :v}], [:"$1"]}]
+      spec = [{:"$1", [{:"=:=", {:element, 2, :"$1"}, {:const, :v}}], [:"$1"]}]
 
       expect(Voyager.ErpcMock, :call, fn _node, mod, fun, args, _timeout ->
         send(test, {:called, mod, fun, args})

--- a/test/voyager/services/ets/search_test.exs
+++ b/test/voyager/services/ets/search_test.exs
@@ -213,7 +213,7 @@ defmodule Voyager.Services.Ets.SearchTest do
       assert_received {:called, :voyager_agent, :ets_select_spec,
                        [:t, ^spec, 10, @budget, :undefined]}
 
-      refute_received {:called, :ets, _}
+      refute_received {:called, :ets, _, _}
     end
   end
 

--- a/test/voyager/services/ets/search_test.exs
+++ b/test/voyager/services/ets/search_test.exs
@@ -97,12 +97,12 @@ defmodule Voyager.Services.Ets.SearchTest do
                Search.chunk(@node, :t, {:key_eq, :k}, 10, -1, nil, @timeout)
     end
 
-    test "rejects a limit outside Fetch.chunk_sizes/0 without a remote call" do
+    test "rejects a non-positive or non-integer limit without a remote call" do
       assert {:error, :invalid_limit} =
-               Search.chunk(@node, :t, {:key_eq, :k}, 15, @budget, nil, @timeout)
+               Search.chunk(@node, :t, {:key_eq, :k}, 0, @budget, nil, @timeout)
 
       assert {:error, :invalid_limit} =
-               Search.chunk(@node, :t, {:element_eq, 2, :v}, 15, @budget, nil, @timeout)
+               Search.chunk(@node, :t, {:element_eq, 2, :v}, :ten, @budget, nil, @timeout)
     end
 
     test "key_eq looks up through the agent without fetching table info" do

--- a/test/voyager/services/ets/search_test.exs
+++ b/test/voyager/services/ets/search_test.exs
@@ -97,15 +97,11 @@ defmodule Voyager.Services.Ets.SearchTest do
                Search.chunk(@node, :t, {:key_eq, :k}, 10, -1, nil, @timeout)
     end
 
-    test "key_eq compiles using table keypos and selects through the agent" do
-      stub_info(2)
-
-      spec = [{:"$1", [{:"=:=", {:element, 2, :"$1"}, {:const, :the_key}}], [:"$1"]}]
-
+    test "key_eq looks up through the agent without fetching table info" do
       expect(Voyager.ErpcMock, :call, fn @node,
                                          :voyager_agent,
-                                         :ets_select_spec,
-                                         [:t, ^spec, 10, @budget, :undefined],
+                                         :ets_lookup,
+                                         [:t, :the_key, @budget],
                                          @timeout ->
         ok_chunk([{1, :the_key}])
       end)
@@ -185,13 +181,13 @@ defmodule Voyager.Services.Ets.SearchTest do
       refute chunk.truncated?
     end
 
-    test "propagates :not_found from info for a key query" do
+    test "propagates :not_found from info for a key prefix query" do
       expect(Voyager.ErpcMock, :call, fn @node, :ets, :info, [:t, :keypos], @timeout ->
         :undefined
       end)
 
       assert {:error, :not_found} =
-               Search.chunk(@node, :t, {:key_eq, :k}, 10, @budget, nil, @timeout)
+               Search.chunk(@node, :t, {:key_prefix, <<"ab">>}, 10, @budget, nil, @timeout)
     end
 
     test "does not retry a missing agent export as :ets.select" do

--- a/test/voyager/services/ets/search_test.exs
+++ b/test/voyager/services/ets/search_test.exs
@@ -98,7 +98,7 @@ defmodule Voyager.Services.Ets.SearchTest do
     end
 
     test "key_eq compiles using table keypos and selects through the agent" do
-      stub_info(keypos: 2)
+      stub_info(2)
 
       spec = [{:"$1", [{:"=:=", {:element, 2, :"$1"}, {:const, :the_key}}], [:"$1"]}]
 
@@ -120,7 +120,7 @@ defmodule Voyager.Services.Ets.SearchTest do
     end
 
     test "key_prefix compiles using table keypos" do
-      stub_info(keypos: 1)
+      stub_info(1)
 
       spec =
         [
@@ -186,7 +186,9 @@ defmodule Voyager.Services.Ets.SearchTest do
     end
 
     test "propagates :not_found from info for a key query" do
-      expect(Voyager.ErpcMock, :call, fn @node, :ets, :info, [:t], @timeout -> :undefined end)
+      expect(Voyager.ErpcMock, :call, fn @node, :ets, :info, [:t, :keypos], @timeout ->
+        :undefined
+      end)
 
       assert {:error, :not_found} =
                Search.chunk(@node, :t, {:key_eq, :k}, 10, @budget, nil, @timeout)
@@ -215,33 +217,9 @@ defmodule Voyager.Services.Ets.SearchTest do
     {:ok, %{records: records, continuation: continuation, truncated: truncated}}
   end
 
-  defp stub_info(overrides) do
-    info = info_kw(overrides)
-
-    expect(Voyager.ErpcMock, :call, fn @node, :ets, :info, [:t], @timeout ->
-      info
+  defp stub_info(keypos) do
+    expect(Voyager.ErpcMock, :call, fn @node, :ets, :info, [:t, :keypos], @timeout ->
+      keypos
     end)
-
-    expect(Voyager.ErpcMock, :call, fn @node, :erlang, :system_info, [:wordsize], @timeout ->
-      8
-    end)
-  end
-
-  defp info_kw(overrides) do
-    [
-      name: :t,
-      named_table: true,
-      protection: :public,
-      type: :set,
-      size: 0,
-      memory: 1,
-      owner: self(),
-      heir: :none,
-      keypos: 1,
-      compressed: false,
-      read_concurrency: false,
-      write_concurrency: false
-    ]
-    |> Keyword.merge(overrides)
   end
 end

--- a/test/voyager/services/ets/search_test.exs
+++ b/test/voyager/services/ets/search_test.exs
@@ -97,6 +97,14 @@ defmodule Voyager.Services.Ets.SearchTest do
                Search.chunk(@node, :t, {:key_eq, :k}, 10, -1, nil, @timeout)
     end
 
+    test "rejects a limit outside Fetch.chunk_sizes/0 without a remote call" do
+      assert {:error, :invalid_limit} =
+               Search.chunk(@node, :t, {:key_eq, :k}, 15, @budget, nil, @timeout)
+
+      assert {:error, :invalid_limit} =
+               Search.chunk(@node, :t, {:element_eq, 2, :v}, 15, @budget, nil, @timeout)
+    end
+
     test "key_eq looks up through the agent without fetching table info" do
       expect(Voyager.ErpcMock, :call, fn @node,
                                          :voyager_agent,

--- a/test/voyager/services/ets/search_test.exs
+++ b/test/voyager/services/ets/search_test.exs
@@ -1,0 +1,235 @@
+defmodule Voyager.Services.Ets.SearchTest do
+  use ExUnit.Case, async: true
+
+  import Mox
+
+  alias Voyager.Agent
+  alias Voyager.Services.Ets.Search
+
+  setup :verify_on_exit!
+
+  @node :"peer@127.0.0.1"
+  @timeout 3_000
+  @budget Agent.default_budget()
+  @max_prefix_bytes 512
+
+  describe "compile/2" do
+    test "key_eq compiles an element-equals spec and matches via :ets.test_ms/2" do
+      assert {:ok, spec} = Search.compile({:key_eq, :k}, 1)
+      assert {:ok, {:k, 1}} = :ets.test_ms({:k, 1}, spec)
+      assert {:ok, false} = :ets.test_ms({:other, 1}, spec)
+    end
+
+    test "key_eq at keypos 2 matches the key field, not element 1" do
+      assert {:ok, spec} = Search.compile({:key_eq, :k}, 2)
+      assert {:ok, {1, :k}} = :ets.test_ms({1, :k}, spec)
+      assert {:ok, false} = :ets.test_ms({:k, 1}, spec)
+    end
+
+    test "key_prefix matches a binary key prefix and skips non-binaries" do
+      assert {:ok, spec} = Search.compile({:key_prefix, <<"ab">>}, 1)
+      assert {:ok, {<<"abc">>, 1}} = :ets.test_ms({<<"abc">>, 1}, spec)
+      assert {:ok, false} = :ets.test_ms({<<"xbc">>, 1}, spec)
+      assert {:ok, false} = :ets.test_ms({:atom, 1}, spec)
+      assert {:ok, false} = :ets.test_ms({<<"a">>, 1}, spec)
+    end
+
+    test "element_eq matches a non-key field" do
+      assert {:ok, spec} = Search.compile({:element_eq, 2, :v})
+      assert {:ok, {:k, :v}} = :ets.test_ms({:k, :v}, spec)
+      assert {:ok, false} = :ets.test_ms({:k, :other}, spec)
+    end
+
+    test "rejects a match-spec string" do
+      assert {:error, :invalid_query} = Search.compile("fn x -> true end")
+      assert {:error, :invalid_query} = Search.compile("[{:'$1', [], [:'$1']}]")
+    end
+
+    test "rejects a tuple as a key or field value" do
+      assert {:error, :invalid_query} = Search.compile({:key_eq, {:tuple, 1}})
+      assert {:error, :invalid_query} = Search.compile({:element_eq, 1, %{a: 1}})
+    end
+
+    test "rejects an empty or oversized key prefix" do
+      assert {:error, :invalid_query} = Search.compile({:key_prefix, <<>>})
+
+      oversized = :binary.copy(<<"a">>, @max_prefix_bytes + 1)
+      assert {:error, :invalid_query} = Search.compile({:key_prefix, oversized})
+    end
+
+    test "rejects a non-positive element index" do
+      assert {:error, :invalid_query} = Search.compile({:element_eq, 0, :v})
+      assert {:error, :invalid_query} = Search.compile({:element_eq, -1, :v})
+    end
+  end
+
+  describe "chunk/7" do
+    test "rejects an invalid query without a remote call" do
+      assert {:error, :invalid_query} =
+               Search.chunk(@node, :t, "[{:'$1', [], [:'$1']}]", 10, @budget, nil, @timeout)
+
+      assert {:error, :invalid_query} =
+               Search.chunk(@node, :t, {:key_eq, {1, 2}}, 10, @budget, nil, @timeout)
+
+      assert {:error, :invalid_query} =
+               Search.chunk(@node, :t, {:key_prefix, <<>>}, 10, @budget, nil, @timeout)
+    end
+
+    test "rejects a handle that is not an atom or reference without a remote call" do
+      assert {:error, :invalid_table} =
+               Search.chunk(@node, self(), {:key_eq, :k}, 10, @budget, nil, @timeout)
+    end
+
+    test "rejects a negative budget without a remote call" do
+      assert {:error, :invalid_budget} =
+               Search.chunk(@node, :t, {:key_eq, :k}, 10, -1, nil, @timeout)
+    end
+
+    test "key_eq compiles using table keypos and selects through the agent" do
+      stub_info(keypos: 2)
+
+      spec = [{:"$1", [{:"=:=", {:element, 2, :"$1"}, :the_key}], [:"$1"]}]
+
+      expect(Voyager.ErpcMock, :call, fn @node,
+                                         :voyager_agent,
+                                         :ets_select_spec,
+                                         [:t, ^spec, 10, @budget, :undefined],
+                                         @timeout ->
+        ok_chunk([{1, :the_key}])
+      end)
+
+      assert {:ok, chunk} =
+               Search.chunk(@node, :t, {:key_eq, :the_key}, 10, @budget, nil, @timeout)
+
+      assert chunk.records == [{1, :the_key}]
+      refute Map.has_key?(chunk, :via)
+      assert chunk.continuation == nil
+      refute chunk.truncated?
+    end
+
+    test "key_prefix compiles using table keypos" do
+      stub_info(keypos: 1)
+
+      spec =
+        [
+          {:"$1",
+           [
+             {:is_binary, {:element, 1, :"$1"}},
+             {:>=, {:byte_size, {:element, 1, :"$1"}}, 3},
+             {:"=:=", {:binary_part, {:element, 1, :"$1"}, 0, 3}, <<"alp">>}
+           ], [:"$1"]}
+        ]
+
+      expect(Voyager.ErpcMock, :call, fn @node,
+                                         :voyager_agent,
+                                         :ets_select_spec,
+                                         [:t, ^spec, 10, @budget, :undefined],
+                                         @timeout ->
+        ok_chunk([{<<"alpha">>, 1}])
+      end)
+
+      assert {:ok, chunk} =
+               Search.chunk(@node, :t, {:key_prefix, <<"alp">>}, 10, @budget, nil, @timeout)
+
+      assert chunk.records == [{<<"alpha">>, 1}]
+      refute Map.has_key?(chunk, :via)
+      refute chunk.truncated?
+    end
+
+    test "element_eq does not fetch table info" do
+      spec = [{:"$1", [{:"=:=", {:element, 2, :"$1"}, :v}], [:"$1"]}]
+
+      expect(Voyager.ErpcMock, :call, fn @node,
+                                         :voyager_agent,
+                                         :ets_select_spec,
+                                         [:t, ^spec, 10, @budget, :undefined],
+                                         @timeout ->
+        ok_chunk([{:a, :v}])
+      end)
+
+      assert {:ok, chunk} =
+               Search.chunk(@node, :t, {:element_eq, 2, :v}, 10, @budget, nil, @timeout)
+
+      assert chunk.records == [{:a, :v}]
+    end
+
+    test "passes a raw continuation through to the agent" do
+      spec = [{:"$1", [{:"=:=", {:element, 1, :"$1"}, :k}], [:"$1"]}]
+      cont = make_ref()
+
+      expect(Voyager.ErpcMock, :call, fn @node,
+                                         :voyager_agent,
+                                         :ets_select_spec,
+                                         [:t, ^spec, 10, @budget, ^cont],
+                                         @timeout ->
+        ok_chunk([], :undefined)
+      end)
+
+      assert {:ok, chunk} =
+               Search.chunk(@node, :t, {:element_eq, 1, :k}, 10, @budget, cont, @timeout)
+
+      assert chunk.records == []
+      assert chunk.continuation == nil
+      refute chunk.truncated?
+    end
+
+    test "propagates :not_found from info for a key query" do
+      expect(Voyager.ErpcMock, :call, fn @node, :ets, :info, [:t], @timeout -> :undefined end)
+
+      assert {:error, :not_found} =
+               Search.chunk(@node, :t, {:key_eq, :k}, 10, @budget, nil, @timeout)
+    end
+
+    test "does not retry a missing agent export as :ets.select" do
+      test = self()
+      spec = [{:"$1", [{:"=:=", {:element, 2, :"$1"}, :v}], [:"$1"]}]
+
+      expect(Voyager.ErpcMock, :call, fn _node, mod, fun, args, _timeout ->
+        send(test, {:called, mod, fun, args})
+        :erlang.error({:exception, :undef, []})
+      end)
+
+      assert {:error, {:remote_exception, :undef}} =
+               Search.chunk(@node, :t, {:element_eq, 2, :v}, 10, @budget, nil, @timeout)
+
+      assert_received {:called, :voyager_agent, :ets_select_spec,
+                       [:t, ^spec, 10, @budget, :undefined]}
+
+      refute_received {:called, :ets, _}
+    end
+  end
+
+  defp ok_chunk(records, continuation \\ :undefined, truncated \\ false) do
+    {:ok, %{records: records, continuation: continuation, truncated: truncated}}
+  end
+
+  defp stub_info(overrides) do
+    info = info_kw(overrides)
+
+    expect(Voyager.ErpcMock, :call, fn @node, :ets, :info, [:t], @timeout ->
+      info
+    end)
+
+    expect(Voyager.ErpcMock, :call, fn @node, :erlang, :system_info, [:wordsize], @timeout ->
+      8
+    end)
+  end
+
+  defp info_kw(overrides) do
+    [
+      name: :t,
+      named_table: true,
+      protection: :public,
+      type: :set,
+      size: 0,
+      memory: 1,
+      owner: self(),
+      heir: :none,
+      keypos: 1,
+      compressed: false,
+      read_concurrency: false,
+      write_concurrency: false
+    ]
+    |> Keyword.merge(overrides)
+  end
+end

--- a/test/voyager/services/ets/search_test.exs
+++ b/test/voyager/services/ets/search_test.exs
@@ -189,12 +189,12 @@ defmodule Voyager.Services.Ets.SearchTest do
       refute chunk.truncated?
     end
 
-    test "propagates :not_found from info for a key prefix query" do
+    test "maps a missing table on key prefix to :cannot_read" do
       expect(Voyager.ErpcMock, :call, fn @node, :ets, :info, [:t, :keypos], @timeout ->
         :undefined
       end)
 
-      assert {:error, :not_found} =
+      assert {:error, :cannot_read} =
                Search.chunk(@node, :t, {:key_prefix, <<"ab">>}, 10, @budget, nil, @timeout)
     end
 

--- a/test/voyager/voyager_agent_ets_test.exs
+++ b/test/voyager/voyager_agent_ets_test.exs
@@ -3,6 +3,7 @@ defmodule VoyagerAgentEtsTest do
 
   @compile {:no_warn_undefined, :voyager_agent}
 
+  alias Voyager.Services.Ets.Search
   alias Voyager.Test.EtsTable
   alias Voyager.Test.VoyagerAgentFixture
 
@@ -164,6 +165,67 @@ defmodule VoyagerAgentEtsTest do
       before = Process.info(self(), :max_heap_size)
       assert {:ok, _chunk} = @agent_module.ets_lookup(name, :k, @budget)
       assert Process.info(self(), :max_heap_size) == before
+    end
+  end
+
+  describe "ets_select_spec/5" do
+    test "does not require the gen_server to be registered" do
+      name = EtsTable.unique_name()
+      :ets.new(name, [:named_table, :public, :set])
+      :ets.insert(name, {:k, 1})
+      {:ok, spec} = Search.compile({:key_eq, :k})
+
+      assert Process.whereis(@agent_module) == nil
+
+      assert {:ok, %{records: [{:k, 1}], continuation: :undefined, truncated: false}} =
+               @agent_module.ets_select_spec(name, spec, 10, @budget, :undefined)
+    end
+
+    test "pages after an ETF-round-tripped continuation repaired against the caller spec" do
+      name = EtsTable.unique_name()
+      :ets.new(name, [:named_table, :public, :set])
+
+      for i <- 1..25, do: :ets.insert(name, {i, :hit})
+      {:ok, spec} = Search.compile({:element_eq, 2, :hit})
+
+      assert {:ok, %{records: records, continuation: cont, truncated: false}} =
+               @agent_module.ets_select_spec(name, spec, 10, @budget, :undefined)
+
+      assert length(records) == 10
+      assert Enum.all?(records, fn {_i, tag} -> tag == :hit end)
+
+      broken = :erlang.binary_to_term(:erlang.term_to_binary(cont))
+      :erlang.garbage_collect()
+
+      assert {:ok, %{records: more, continuation: cont2, truncated: false}} =
+               @agent_module.ets_select_spec(name, spec, 10, @budget, broken)
+
+      assert length(more) == 10
+      assert Enum.all?(more, fn {_i, tag} -> tag == :hit end)
+
+      assert {:ok, %{records: last, continuation: :undefined, truncated: false}} =
+               @agent_module.ets_select_spec(name, spec, 10, @budget, cont2)
+
+      assert length(last) == 5
+    end
+
+    test "raises badarg for a spec that is not a one-clause source MS" do
+      name = EtsTable.unique_name()
+      :ets.new(name, [:named_table, :public, :set])
+
+      assert_raise ArgumentError, fn ->
+        @agent_module.ets_select_spec(name, "not a spec", 10, @budget, :undefined)
+      end
+    end
+
+    test "raises badarg for a negative budget" do
+      name = EtsTable.unique_name()
+      :ets.new(name, [:named_table, :public, :set])
+      {:ok, spec} = Search.compile({:key_eq, :k})
+
+      assert_raise ArgumentError, fn ->
+        @agent_module.ets_select_spec(name, spec, 10, -1, :undefined)
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary

[VOY-231](https://linear.app/softwaremansion/issue/VOY-231) (parent [VOY-27](https://linear.app/softwaremansion/issue/VOY-27)): match-spec search with the same agent-only rule as records.

Stacked on slimmed 230 ([PR #219](https://github.com/software-mansion/voyager/pull/219)). **No MFA `:ets.select` fallback, no export probe, no host `Sanitize`, no `search_live_test`.** The old stack is frozen on [`experimental/ets-mfa-fallback-and-live-tests`](https://github.com/software-mansion/voyager/tree/experimental/ets-mfa-fallback-and-live-tests).

## Public API

```elixir
Search.compile(query, keypos \\ 1)
Search.chunk(node, table, query, limit, continuation \\ nil, timeout)
```

Queries: `{:key_eq, scalar}`, `{:key_prefix, binary}`, `{:element_eq, pos, scalar}`. No eval of user or LLM match-spec strings. Prefix cap is a local `@max_prefix_bytes 512`.

`chunk/6` loads `keypos` via metadata `Remote.info/3` (key queries only), compiles a **source** MS, then `Fetch.select_spec/6` → `Voyager.Agent.call(:ets_select_spec, …)`. Missing agent is `:undef` and drops the session. `badarg` → `:cannot_read`.

## Agent

`ets_select_spec/4` shares `do_select/4` with match-all chunk: isolate + truncate + `ets:repair_continuation/2` against the **caller spec**. `valid_spec/1` requires a one-clause source MS.

## Test plan

- [x] `mix test test/voyager/services/ets/ test/voyager/voyager_agent_ets_test.exs`
- [x] `mix precommit`
- [x] Compile key_eq / key_prefix / element_eq; reject strings, empty/oversized prefix, bad scalars
- [x] `chunk` calls `:voyager_agent.ets_select_spec` (not `:ets.select`); continuation passed through
- [x] Missing export is **not** retried as `:ets.select`
- [x] Agent pages after an ETF-round-tripped continuation; invalid spec is `badarg`